### PR TITLE
feat(deploy): add support for merge auto-deploys

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -5,6 +5,9 @@ Metrics/BlockLength:
 Metrics/ClassLength:
   CountAsOne: ["array", "heredoc", "hash", "method_call"]
 
+Metrics/MethodLength:
+  CountAsOne: ["array", "heredoc", "method_call"]
+
 Metrics/ParameterLists:
   Max: 10
 

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -10,7 +10,7 @@ inputs:
     default: "planningcenter"
   automerge:
     description: "Do you want to automerge the PRs?  This should be dynamic based on if it is a major release"
-    required: true
+    required: false
   only:
     description: "Only run on specific repos. This is a comma separated list of repo names (ie 'people,services,groups')"
     required: false

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -25,6 +25,14 @@ inputs:
     description: "JSON string of repo names and their specific upgrade commands. Useful for monorepos where the package.json does not exist in the root directory."
     required: false
     default: "{}"
+  change-method:
+    description: "The method to use to create the changes. Options are 'pr' or 'merge'."
+    required: false
+    default: "pr"
+  branch-name:
+    description: "When `merge` is used as the change-method, this is the branch where the changes will be merged."
+    required: false
+    default: "staging"
   include:
     description: "repos to include without checking. Comma separated list"
     required: false
@@ -80,6 +88,8 @@ runs:
         ONLY: ${{ inputs.only }}
         AUTOMERGE: ${{ inputs.automerge }}
         UPGRADE_COMMANDS: ${{ inputs.upgrade-commands }}
+        BRANCH_NAME: ${{ inputs.branch-name }}
+        CHANGE_METHOD: ${{ inputs.change-method }}
         INCLUDE: ${{ inputs.include }}
         EXCLUDE: ${{ inputs.exclude }}
       working-directory: ${{ github.action_path}}

--- a/deploy/lib/deployer.rb
+++ b/deploy/lib/deployer.rb
@@ -5,6 +5,8 @@ require_relative "deployer/command_line"
 require_relative "deployer/config"
 require_relative "deployer/errors"
 require_relative "deployer/repo"
+require_relative "deployer/repo/base_updater"
+require_relative "deployer/repo/merge_updater"
 require_relative "deployer/repo/pull_request_updater"
 require_relative "deployer/repos"
 

--- a/deploy/lib/deployer.rb
+++ b/deploy/lib/deployer.rb
@@ -23,7 +23,7 @@ class Deployer
       repo.update_package
       log repo.success_message
     rescue BaseError, StandardError => e
-      failed_repos.push(repo)
+      failed_repos.push(repo.name)
       log failure_message(error: e, repo: repo)
     end
     return unless failed_repos.any?

--- a/deploy/lib/deployer.rb
+++ b/deploy/lib/deployer.rb
@@ -5,6 +5,7 @@ require_relative "deployer/command_line"
 require_relative "deployer/config"
 require_relative "deployer/errors"
 require_relative "deployer/repo"
+require_relative "deployer/repo/pull_request_updater"
 require_relative "deployer/repos"
 
 class Deployer

--- a/deploy/lib/deployer/config.rb
+++ b/deploy/lib/deployer/config.rb
@@ -1,10 +1,12 @@
 class Deployer
   class Config
-    def initialize(
+    def initialize( # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
       github_token:,
       owner:,
       package_name:,
       version:,
+      change_method: "pr",
+      branch_name: "main",
       automerge: false,
       only: [],
       upgrade_commands: {},
@@ -20,6 +22,8 @@ class Deployer
       @upgrade_commands = upgrade_commands
       @include = include
       @exclude = exclude
+      @branch_name = branch_name
+      @change_method = change_method
     end
 
     attr_reader :github_token,
@@ -27,10 +31,12 @@ class Deployer
                 :package_name,
                 :version,
                 :automerge,
+                :branch_name,
                 :only,
                 :upgrade_commands,
                 :include,
-                :exclude
+                :exclude,
+                :change_method
 
     def client
       @client ||=

--- a/deploy/lib/deployer/repo.rb
+++ b/deploy/lib/deployer/repo.rb
@@ -6,14 +6,11 @@ class Deployer
     end
 
     def update_package
-      run
-    rescue StandardError => e
-      cleanup
-      raise e
+      updater.run
     end
 
     def success_message
-      "Successfully updated #{package_name} to #{version} in #{name} (https://github.com/#{owner}/#{name}/pull/#{pr_number})"
+      "Successfully updated #{package_name} to #{version} in #{name}#{updater.message_suffix}"
     end
 
     attr_reader :name
@@ -22,104 +19,12 @@ class Deployer
 
     attr_reader :config, :pr_number
 
-    def run
-      clone_repo
-      Dir.chdir(name) do
-        create_branch
-        run_upgrade_command
-        commit_and_push_changes
-        create_pr
-        automerge_pr
-      end
-      cleanup
+    def updater
+      @updater ||= updater_class.new(name, config: config)
     end
 
-    def clone_repo
-      log "Cloning #{name}"
-      command_line.execute(
-        "git clone https://#{config.github_token}:x-oauth-basic@github.com/#{owner}/#{name}.git --depth=1",
-        error_class: FailedToCloneRepo
-      )
-    end
-
-    def create_branch
-      log "Creating branch #{branch_name}"
-      command_line.execute(
-        "git checkout -b #{branch_name}",
-        error_class: CreateBranchFailure
-      )
-    end
-
-    def run_upgrade_command
-      log "Running #{upgrade_command}"
-      command_line.execute(
-        "#{upgrade_command} #{package_name}@#{version}",
-        error_class: UpgradeCommandFailure
-      )
-    end
-
-    def commit_and_push_changes
-      command_line.execute(
-        "git commit -am 'bump #{package_name} to #{version}'",
-        error_class: CommitChangesFailure
-      )
-      command_line.execute(
-        "git push origin #{branch_name} -f",
-        error_class: PushBranchFailure
-      )
-    end
-
-    def create_pr
-      response =
-        client.create_pull_request(
-          "#{owner}/#{name}",
-          "main",
-          branch_name,
-          pr_title,
-          pr_body
-        )
-      raise FailedToCreatePRError, response if response.number.nil?
-
-      @pr_number = response.number
-    end
-
-    def automerge_pr
-      return unless automerge
-
-      log "Merging PR #{pr_number}"
-      command_line.execute(
-        "gh pr merge #{pr_number} --auto --merge",
-        error_class: AutoMergeFailure
-      )
-    end
-
-    def cleanup
-      FileUtils.rm_rf(name)
-    end
-
-    def branch_name
-      unsanitized_branch_name = "pco-release-#{package_name}-#{version}"
-      unsanitized_branch_name.gsub(/[^a-zA-Z0-9]/, "-")
-    end
-
-    def upgrade_command
-      upgrade_commands[name].nil? ? "yarn upgrade" : upgrade_commands[name]
-    end
-
-    def pr_title
-      "[Automated] bump #{package_name} to #{version}"
-    end
-
-    def pr_body
-      "This is an automated PR that updates #{package_name} to version #{version}. Please ensure that all checks pass."
-    end
-
-    def log(message)
-      config.log(message)
-    end
-
-    def owner
-      config.owner
+    def updater_class
+      PullRequestUpdater
     end
 
     def package_name
@@ -128,22 +33,6 @@ class Deployer
 
     def version
       config.version
-    end
-
-    def upgrade_commands
-      config.upgrade_commands
-    end
-
-    def client
-      config.client
-    end
-
-    def automerge
-      config.automerge
-    end
-
-    def command_line
-      @command_line ||= CommandLine.new(config)
     end
   end
 end

--- a/deploy/lib/deployer/repo.rb
+++ b/deploy/lib/deployer/repo.rb
@@ -17,14 +17,19 @@ class Deployer
 
     private
 
-    attr_reader :config, :pr_number
+    attr_reader :config
 
     def updater
       @updater ||= updater_class.new(name, config: config)
     end
 
     def updater_class
-      PullRequestUpdater
+      case config.change_method
+      when "merge"
+        MergeUpdater
+      else
+        PullRequestUpdater
+      end
     end
 
     def package_name

--- a/deploy/lib/deployer/repo/base_updater.rb
+++ b/deploy/lib/deployer/repo/base_updater.rb
@@ -1,0 +1,100 @@
+class Deployer
+  class Repo
+    class BaseUpdater
+      def initialize(name, config:)
+        @name = name
+        @config = config
+      end
+
+      def run
+        make_changes
+      rescue StandardError => e
+        cleanup
+        raise e
+      end
+
+      protected
+
+      attr_reader :name, :config
+
+      def make_changes
+        raise NotImplementedError
+      end
+
+      def clone_suffix
+        ""
+      end
+
+      def branch_name
+        raise NotImplementedError
+      end
+
+      def clone_repo
+        log "Cloning #{name}"
+        command_line.execute(
+          "git clone https://#{config.github_token}:x-oauth-basic@github.com/#{owner}/#{name}.git#{clone_suffix}",
+          error_class: FailedToCloneRepo
+        )
+      end
+
+      def create_branch
+        log "Creating branch #{branch_name}"
+        command_line.execute(
+          "git checkout #{branch_name} || git checkout -b #{branch_name}",
+          error_class: CreateBranchFailure
+        )
+      end
+
+      def run_upgrade_command
+        log "Running #{upgrade_command}"
+        command_line.execute(
+          "#{upgrade_command} #{package_name}@#{version}",
+          error_class: UpgradeCommandFailure
+        )
+      end
+
+      def commit_and_push_changes
+        command_line.execute(
+          "git commit -am 'bump #{package_name} to #{version}'",
+          error_class: CommitChangesFailure
+        )
+        command_line.execute(
+          "git push origin #{branch_name} -f",
+          error_class: PushBranchFailure
+        )
+      end
+
+      def cleanup
+        FileUtils.rm_rf(name)
+      end
+
+      def upgrade_command
+        upgrade_commands[name].nil? ? "yarn upgrade" : upgrade_commands[name]
+      end
+
+      def log(message)
+        config.log(message)
+      end
+
+      def owner
+        config.owner
+      end
+
+      def package_name
+        config.package_name
+      end
+
+      def version
+        config.version
+      end
+
+      def upgrade_commands
+        config.upgrade_commands
+      end
+
+      def command_line
+        @command_line ||= CommandLine.new(config)
+      end
+    end
+  end
+end

--- a/deploy/lib/deployer/repo/merge_updater.rb
+++ b/deploy/lib/deployer/repo/merge_updater.rb
@@ -1,0 +1,25 @@
+class Deployer
+  class Repo
+    class MergeUpdater < BaseUpdater
+      def message_suffix
+        ""
+      end
+
+      private
+
+      def make_changes
+        clone_repo
+        Dir.chdir(name) do
+          create_branch
+          run_upgrade_command
+          commit_and_push_changes
+        end
+        cleanup
+      end
+
+      def branch_name
+        config.branch_name
+      end
+    end
+  end
+end

--- a/deploy/lib/deployer/repo/pull_request_updater.rb
+++ b/deploy/lib/deployer/repo/pull_request_updater.rb
@@ -1,0 +1,153 @@
+class Deployer
+  class Repo
+    class PullRequestUpdater
+      def initialize(name, config:)
+        @name = name
+        @config = config
+      end
+
+      def run
+        make_changes
+      rescue StandardError => e
+        cleanup
+        raise e
+      end
+
+      def message_suffix
+        " (https://github.com/#{owner}/#{name}/pull/#{pr_number})"
+      end
+
+      private
+
+      attr_reader :name, :config, :pr_number
+
+      def make_changes
+        clone_repo
+        Dir.chdir(name) do
+          create_branch
+          run_upgrade_command
+          commit_and_push_changes
+          create_pr
+          automerge_pr
+        end
+        cleanup
+      end
+
+      def clone_suffix
+        " --depth=1"
+      end
+
+      def branch_name
+        unsanitized_branch_name = "pco-release-#{package_name}-#{version}"
+        unsanitized_branch_name.gsub(/[^a-zA-Z0-9]/, "-")
+      end
+
+      def clone_repo
+        log "Cloning #{name}"
+        command_line.execute(
+          "git clone https://#{config.github_token}:x-oauth-basic@github.com/#{owner}/#{name}.git --depth=1",
+          error_class: FailedToCloneRepo
+        )
+      end
+
+      def create_branch
+        log "Creating branch #{branch_name}"
+        command_line.execute(
+          "git checkout -b #{branch_name}",
+          error_class: CreateBranchFailure
+        )
+      end
+
+      def run_upgrade_command
+        log "Running #{upgrade_command}"
+        command_line.execute(
+          "#{upgrade_command} #{package_name}@#{version}",
+          error_class: UpgradeCommandFailure
+        )
+      end
+
+      def commit_and_push_changes
+        command_line.execute(
+          "git commit -am 'bump #{package_name} to #{version}'",
+          error_class: CommitChangesFailure
+        )
+        command_line.execute(
+          "git push origin #{branch_name} -f",
+          error_class: PushBranchFailure
+        )
+      end
+
+      def create_pr
+        response =
+          client.create_pull_request(
+            "#{owner}/#{name}",
+            "main",
+            branch_name,
+            pr_title,
+            pr_body
+          )
+        raise FailedToCreatePRError, response if response.number.nil?
+
+        @pr_number = response.number
+      end
+
+      def automerge_pr
+        return unless automerge
+
+        log "Merging PR #{pr_number}"
+        command_line.execute(
+          "gh pr merge #{pr_number} --auto --merge",
+          error_class: AutoMergeFailure
+        )
+      end
+
+      def pr_title
+        "[Automated] bump #{package_name} to #{version}"
+      end
+
+      def pr_body
+        "This is an automated PR that updates #{package_name} to version #{version}. Please ensure that all checks pass."
+      end
+
+      def client
+        config.client
+      end
+
+      def automerge
+        config.automerge
+      end
+
+      def cleanup
+        FileUtils.rm_rf(name)
+      end
+
+      def upgrade_command
+        upgrade_commands[name].nil? ? "yarn upgrade" : upgrade_commands[name]
+      end
+
+      def log(message)
+        config.log(message)
+      end
+
+      def owner
+        config.owner
+      end
+
+      def package_name
+        config.package_name
+      end
+
+      def version
+        config.version
+      end
+
+      def upgrade_commands
+        config.upgrade_commands
+      end
+
+      def command_line
+        @command_line ||= CommandLine.new(config)
+      end
+    end
+  end
+end

--- a/deploy/lib/deployer/repo/pull_request_updater.rb
+++ b/deploy/lib/deployer/repo/pull_request_updater.rb
@@ -1,25 +1,13 @@
 class Deployer
   class Repo
-    class PullRequestUpdater
-      def initialize(name, config:)
-        @name = name
-        @config = config
-      end
-
-      def run
-        make_changes
-      rescue StandardError => e
-        cleanup
-        raise e
-      end
-
+    class PullRequestUpdater < BaseUpdater
       def message_suffix
         " (https://github.com/#{owner}/#{name}/pull/#{pr_number})"
       end
 
       private
 
-      attr_reader :name, :config, :pr_number
+      attr_reader :pr_number
 
       def make_changes
         clone_repo
@@ -40,41 +28,6 @@ class Deployer
       def branch_name
         unsanitized_branch_name = "pco-release-#{package_name}-#{version}"
         unsanitized_branch_name.gsub(/[^a-zA-Z0-9]/, "-")
-      end
-
-      def clone_repo
-        log "Cloning #{name}"
-        command_line.execute(
-          "git clone https://#{config.github_token}:x-oauth-basic@github.com/#{owner}/#{name}.git --depth=1",
-          error_class: FailedToCloneRepo
-        )
-      end
-
-      def create_branch
-        log "Creating branch #{branch_name}"
-        command_line.execute(
-          "git checkout -b #{branch_name}",
-          error_class: CreateBranchFailure
-        )
-      end
-
-      def run_upgrade_command
-        log "Running #{upgrade_command}"
-        command_line.execute(
-          "#{upgrade_command} #{package_name}@#{version}",
-          error_class: UpgradeCommandFailure
-        )
-      end
-
-      def commit_and_push_changes
-        command_line.execute(
-          "git commit -am 'bump #{package_name} to #{version}'",
-          error_class: CommitChangesFailure
-        )
-        command_line.execute(
-          "git push origin #{branch_name} -f",
-          error_class: PushBranchFailure
-        )
       end
 
       def create_pr
@@ -115,38 +68,6 @@ class Deployer
 
       def automerge
         config.automerge
-      end
-
-      def cleanup
-        FileUtils.rm_rf(name)
-      end
-
-      def upgrade_command
-        upgrade_commands[name].nil? ? "yarn upgrade" : upgrade_commands[name]
-      end
-
-      def log(message)
-        config.log(message)
-      end
-
-      def owner
-        config.owner
-      end
-
-      def package_name
-        config.package_name
-      end
-
-      def version
-        config.version
-      end
-
-      def upgrade_commands
-        config.upgrade_commands
-      end
-
-      def command_line
-        @command_line ||= CommandLine.new(config)
       end
     end
   end

--- a/deploy/run.rb
+++ b/deploy/run.rb
@@ -9,6 +9,8 @@ config =
     only: ENV["ONLY"].split(","),
     automerge: ENV["AUTOMERGE"] == "true",
     upgrade_commands: JSON.parse(ENV["UPGRADE_COMMANDS"]),
+    branch_name: ENV["BRANCH_NAME"],
+    change_method: ENV["CHANGE_METHOD"],
     include: ENV["INCLUDE"].split(","),
     exclude: ENV["EXCLUDE"].split(",")
   )

--- a/deploy/spec/deployer/config_spec.rb
+++ b/deploy/spec/deployer/config_spec.rb
@@ -1,0 +1,23 @@
+describe Deployer::Config do
+  it "keeps track of the config options for a run" do
+    config =
+      Deployer::Config.new(
+        github_token: "",
+        owner: "planningcenter",
+        package_name: "@planningcenter/tapestry-react",
+        version: "1.0.1"
+      )
+
+    expect(config.github_token).to eq("")
+    expect(config.owner).to eq("planningcenter")
+    expect(config.package_name).to eq("@planningcenter/tapestry-react")
+    expect(config.version).to eq("1.0.1")
+    expect(config.automerge).to eq(false)
+    expect(config.only).to eq([])
+    expect(config.upgrade_commands).to eq({})
+    expect(config.include).to eq([])
+    expect(config.exclude).to eq([])
+    expect(config.change_method).to eq("pr")
+    expect(config.branch_name).to eq("main")
+  end
+end

--- a/deploy/spec/deployer_spec.rb
+++ b/deploy/spec/deployer_spec.rb
@@ -22,7 +22,7 @@ describe Deployer do
       )
 
       allow(Open3).to receive(:capture3).with(
-        "gh repo clone planningcenter/topbar -- --depth=1"
+        "git clone https://:x-oauth-basic@github.com/planningcenter/topbar.git --depth=1"
       ) do
         Dir.mkdir("topbar") unless Dir.exist?("topbar")
         ["", "", double(success?: true)]

--- a/deploy/spec/deployer_spec.rb
+++ b/deploy/spec/deployer_spec.rb
@@ -1,49 +1,83 @@
 describe Deployer do
   let(:json_headers) { { "Content-Type" => "application/json" } }
 
+  def stub_find_repos(repo_name)
+    repos = [{ "id" => 11, "name" => repo_name, "archived" => false }]
+    stub_request(
+      :get,
+      "https://api.github.com/orgs/planningcenter/repos?per_page=100"
+    ).to_return(body: repos.to_json, headers: json_headers)
+  end
+
+  def stub_read_package_json(repo_name)
+    stub_request(
+      :get,
+      "https://api.github.com/repos/planningcenter/#{repo_name}/contents/package.json"
+    ).to_return(
+      body: {
+        content:
+          Base64.encode64(
+            '{"dependencies": {"@planningcenter/tapestry-react": "1.0.0"}}'
+          )
+      }.to_json,
+      headers: json_headers
+    )
+  end
+
+  def stub_clone_repo(suffix = "")
+    allow(Open3).to receive(:capture3).with(
+      "git clone https://:x-oauth-basic@github.com/planningcenter/topbar.git#{suffix}"
+    ) do
+      Dir.mkdir("topbar") unless Dir.exist?("topbar")
+      ["", "", double(success?: true)]
+    end
+  end
+
+  def stub_checkout_branch(
+    branch_name = "pco-release--planningcenter-tapestry-react-1-0-1"
+  )
+    allow(Open3).to receive(:capture3).with(
+      "git checkout #{branch_name} || git checkout -b #{branch_name}"
+    ).and_return(["", "", double(success?: true)])
+  end
+
+  def stub_upgrade
+    allow(Open3).to receive(:capture3).with(
+      "yarn upgrade @planningcenter/tapestry-react@1.0.1"
+    ).and_return(["", "", double(success?: true)])
+  end
+
+  def stub_commit_changes
+    allow(Open3).to receive(:capture3).with(
+      "git commit -am 'bump @planningcenter/tapestry-react to 1.0.1'"
+    ).and_return(["", "", double(success?: true)])
+  end
+
+  def stub_push_changes(
+    branch_name = "pco-release--planningcenter-tapestry-react-1-0-1"
+  )
+    allow(Open3).to receive(:capture3).with(
+      "git push origin #{branch_name} -f"
+    ).and_return(["", "", double(success?: true)])
+  end
+
+  def stub_create_pr
+    stub_request(
+      :post,
+      "https://api.github.com/repos/planningcenter/topbar/pulls"
+    ).to_return(body: { number: 1 }.to_json, headers: json_headers)
+  end
+
   describe "#run" do
     it "updates the package in the specified repositories" do
-      repos = [{ "id" => 11, "name" => "topbar", "archived" => false }]
-      stub_request(
-        :get,
-        "https://api.github.com/orgs/planningcenter/repos?per_page=100"
-      ).to_return(body: repos.to_json, headers: json_headers)
-      stub_request(
-        :get,
-        "https://api.github.com/repos/planningcenter/topbar/contents/package.json"
-      ).to_return(
-        body: {
-          content:
-            Base64.encode64(
-              '{"dependencies": {"@planningcenter/tapestry-react": "1.0.0"}}'
-            )
-        }.to_json,
-        headers: json_headers
-      )
-
-      allow(Open3).to receive(:capture3).with(
-        "git clone https://:x-oauth-basic@github.com/planningcenter/topbar.git --depth=1"
-      ) do
-        Dir.mkdir("topbar") unless Dir.exist?("topbar")
-        ["", "", double(success?: true)]
-      end
-      allow(Open3).to receive(:capture3).with(
-        "git checkout -b pco-release--planningcenter-tapestry-react-1-0-1"
-      ).and_return(["", "", double(success?: true)])
-      allow(Open3).to receive(:capture3).with(
-        "yarn upgrade @planningcenter/tapestry-react@1.0.1"
-      ).and_return(["", "", double(success?: true)])
-      allow(Open3).to receive(:capture3).with(
-        "git commit -am 'bump @planningcenter/tapestry-react to 1.0.1'"
-      ).and_return(["", "", double(success?: true)])
-      allow(Open3).to receive(:capture3).with(
-        "git push origin pco-release--planningcenter-tapestry-react-1-0-1 -f"
-      ).and_return(["", "", double(success?: true)])
-
-      stub_request(
-        :post,
-        "https://api.github.com/repos/planningcenter/topbar/pulls"
-      ).to_return(body: { number: 1 }.to_json, headers: json_headers)
+      stub_find_repos("topbar")
+      stub_read_package_json("topbar")
+      stub_clone_repo(" --depth=1")
+      stub_checkout_branch
+      stub_upgrade
+      stub_commit_changes
+      stub_push_changes
+      stub_create_pr
 
       config =
         Deployer::Config.new(
@@ -58,28 +92,36 @@ describe Deployer do
         "Successfully updated @planningcenter/tapestry-react to 1.0.1 in topbar (https://github.com/planningcenter/topbar/pull/1)"
       )
     end
+
+    context "when specifying a merge" do
+      it "uses the specified branch name" do
+        stub_find_repos("topbar")
+        stub_read_package_json("topbar")
+        stub_clone_repo
+
+        stub_checkout_branch("staging") # Unique branch name
+        stub_upgrade
+        stub_commit_changes
+        stub_push_changes("staging") # Unique branch name
+
+        config =
+          Deployer::Config.new(
+            github_token: "",
+            owner: "planningcenter",
+            package_name: "@planningcenter/tapestry-react",
+            version: "1.0.1",
+            change_method: "merge",
+            branch_name: "staging" # Unique branch name
+          )
+        described_class.new(config).run
+      end
+    end
   end
 
   describe "#repos" do
     it "returns a list of repos that contain the package name" do
-      repos = [{ "id" => 11, "name" => "test-repo", "archived" => false }]
-      stub_request(
-        :get,
-        "https://api.github.com/orgs/planningcenter/repos?per_page=100"
-      ).to_return(body: repos.to_json, headers: json_headers)
-
-      stub_request(
-        :get,
-        "https://api.github.com/repos/planningcenter/test-repo/contents/package.json"
-      ).to_return(
-        body: {
-          content:
-            Base64.encode64(
-              '{"dependencies": {"@planningcenter/tapestry-react": "1.0.0"}}'
-            )
-        }.to_json,
-        headers: json_headers
-      )
+      stub_find_repos("test-repo")
+      stub_read_package_json("test-repo")
 
       config =
         Deployer::Config.new(


### PR DESCRIPTION
For prereleases, we want to be able to push updates to either `staging` (for rc's) or a protonova build (for qa releases).  We don't want to go through the hassle of PR's for those, so this PR opens the interface of the action to allow it specify a `change-method` and `branch-name`.  If `change-method` is set to `merge`, then the changes will be merged directly into the branch that is set by `branch-name`.

An example usage might look like this:

```yml
name: Publish

jobs:
  publish-to-npm: ...

  auto-deploy-prerelease:
    needs: publish-to-npm
    runs-on: ubuntu-latest
    steps:
      - name: Build branch name (staging if rc, use PR number and library name if qa) 
        run: |
          tag_name=${{ github.event.release.tag_name }}
          if [[ $VERSION =~ -rc\. ]]; then
            echo "branch_name=staging" >> $GITHUB_ENV
          else
            [[ $tag_name =~ -qa-([0-9]+)\. ]]
            branch_name="proto/my-library-${BASH_REMATCH[1]}"
            echo "branch_name=$branch_name" >> $GITHUB_ENV
          fi
      - uses: planningcenter/pco-release-action/deploy@v1
        if: 'github.event.release.prerelease'
        with:
          github-token: ${{ secrets.GITHUB_TOKEN }}
          change-method: 'merge'
          branch-name: ${{ env.branch_name }}
```

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208142547696348