### PR TITLE
bump undici to 6.19.8

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -2944,9 +2944,9 @@ undici@^5.25.4:
     "@fastify/busboy" "^2.0.0"
 
 undici@^6.0.0:
-  version "6.14.0"
-  resolved "https://registry.yarnpkg.com/undici/-/undici-6.14.0.tgz#c176d7b1744793416f42de7609645a182b968dcc"
-  integrity sha512-esJ/x2QU5boTG6thdA0o4qP3cv/oPx9mcQGcp8TAHI+ZBTa0EvM9Jiyp0ILdPGLGxs5HATTKrJqAK+YhrSFicg==
+  version "6.19.8"
+  resolved "https://registry.yarnpkg.com/undici/-/undici-6.19.8.tgz#002d7c8a28f8cc3a44ff33c3d4be4d85e15d40e1"
+  integrity sha512-U8uCCl2x9TK3WANvmBavymRzxbfFYG+tAu+fgx3zxQy3qdagQqBLwJVrdyO1TBfUXvfKveMKJZhpvUYoOjM+4g==
 
 universal-user-agent@^6.0.0:
   version "6.0.1"


### PR DESCRIPTION
we still use v5 for another dependency, but that is not vulnerable.