### PR TITLE
feat(QA): add combined workflow for deploying QA releases

### DIFF
--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -79,20 +79,20 @@ jobs:
       build-directory: ${{ inputs.build-directory }}
       ref: ${{ needs.create-qa-release.outputs.release-tag }}
       prerelease: true
-  deploy-to-staging-for-consumers:
+  deploy-to-proto-for-consumers:
     needs: [create-qa-release, publish-to-npm]
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
     steps:
-      - name: Push to `staging` for Consumers
-        uses: planningcenter/pco-release-action/deploy@v1
+      - name: Push to protonova branch for Consumers
+        uses: planningcenter/pco-release-action/deploy@km/qa-deploy-combined
         with:
           github-token: ${{ secrets.PICOBOT_JS_DEPLOYMENT }}
           ref: ${{ needs.create-qa-release.outputs.release-tag }}
           change-method: "merge"
-          branch-name: "staging"
+          branch-name: "proto/${{ github.repository }}-${{ github.event.issue.number }}"
           only: ${{ inputs.only }}
           exclude: ${{ inputs.exclude }}
           include: ${{ inputs.include }}

--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -1,0 +1,99 @@
+name: PCO-Release - QA Release Automation
+on:
+  workflow_call:
+    inputs:
+      install-command:
+        description: "The script command to use to install the package's dependencies"
+        required: false
+        type: string
+        default: "yarn install --check-files"
+      build-command:
+        description: "The script command to use to build the package"
+        required: false
+        type: string
+        default: "yarn build"
+      test-command:
+        description: "The script command to use to test the package"
+        required: false
+        type: string
+        default: "yarn test"
+      prepublish-command:
+        description: "The command to run to publish a prerelease version of the package to NPM"
+        required: false
+        type: string
+        default: "npm publish --tag next"
+      cache:
+        description: "Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm, or '' for no caching."
+        required: false
+        type: string
+        default: "yarn"
+      build-directory:
+        description: "The build output directory"
+        required: false
+        type: string
+        default: "dist"
+      only:
+        description: "Only run on specific repos. This is a comma separated list of repo names (ie 'people,services,groups')"
+        required: false
+        type: string
+        default: ""
+      include:
+        description: "repos to include without checking. Comma separated list"
+        required: false
+        type: string
+        default: ""
+      exclude:
+        description: "repos to exclude without checking. Comma separated list"
+        required: false
+        type: string
+        default: ""
+      upgrade-commands:
+        description: "JSON string of repo names and their specific upgrade commands. Useful for monorepos where the package.json does not exist in the root directory."
+        required: false
+        type: string
+        default: "{}"
+jobs:
+  create-qa-release:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '@pco-release qa')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Create QA Pre-Release
+        id: create-qa-release
+        uses: planningcenter/pco-release-action/create-qa-release@v1
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    outputs:
+      release-tag: v${{ env.new_version }}
+  publish-to-npm:
+    needs: create-qa-release
+    uses: planningcenter/pco-release-action/.github/workflows/publish.yml@v1
+    with:
+      install-command: ${{ inputs.install-command }}
+      build-command: ${{ inputs.build-command }}
+      test-command: ${{ inputs.test-command }}
+      prepublish-command: ${{ inputs.prepublish-command }}
+      cache: ${{ inputs.cache }}
+      build-directory: ${{ inputs.build-directory }}
+      ref: ${{ needs.create-qa-release.outputs.release-tag }}
+      prerelease: true
+  deploy-to-staging-for-consumers:
+    needs: [create-qa-release, publish-to-npm]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Push to `staging` for Consumers
+        uses: planningcenter/pco-release-action/deploy@v1
+        with:
+          github-token: ${{ secrets.PICOBOT_JS_DEPLOYMENT }}
+          ref: ${{ needs.create-qa-release.outputs.release-tag }}
+          change-method: "merge"
+          branch-name: "staging"
+          only: ${{ inputs.only }}
+          exclude: ${{ inputs.exclude }}
+          include: ${{ inputs.include }}
+          upgrade-commands: ${{ inputs.upgrade-commands }}

--- a/README.md
+++ b/README.md
@@ -193,6 +193,48 @@ jobs:
     secrets: inherit
 ```
 
+### QA Release
+
+This will be available to create a QA release from a PR for testing a specific branch, publish it, and send it to a protonova environment for all consumers.
+
+#### Configuration variables
+
+You can customize the commands the workflow runs for installing dependencies, building, and testing the package.
+If no options are provided, the defaults will be used.
+
+| Input                | Description                                                                                                                                        | Req'd | Default                      |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- | ----- | ---------------------------- |
+| `build-command`      | The command to run to build the package                                                                                                            | No    | `yarn build`                 |
+| `build-directory`    | The directory containing the build output                                                                                                          | No    | `dist`                       |
+| `cache`              | Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm, or '' for no caching.                   | No    | `yarn`                       |
+| `install-command`    | The command to run to install the package's dependencies                                                                                           | No    | `yarn install --check-files` |
+| `prepublish-command` | The command to publish a prerelease version of the package to NPM                                                                                  | No    | `npm publish --tag next`     |
+| `test-command`       | The command to run to test the package                                                                                                             | No    | `yarn test`                  |
+| `only`               | A comma separated list of repos that will only be updated                                                                                          | No    | ''                           |
+| `include`            | A comma separated list of repos to include without checking for the dependency.                                                                    | No    | ''                           |
+| `exclude`            | A comma separated list of repos to exclude without checking for the dependency.                                                                    | No    | ''                           |
+| `upgrade-commands`   | "JSON string of repo names and their specific upgrade commands. Useful for monorepos where the package.json does not exist in the root directory." | No    | `"{}"`                       |
+
+#### Usage
+
+Create a workflow within your own JavaScript library. As an example, in `.github/workflows/qa.yml`...
+
+```yml
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  create-qa-release-and-deploy:
+    if: (github.event_name == 'workflow_dispatch') || (github.event.issue.pull_request && contains(github.event.comment.body, '@pco-release qa'))
+    permissions:
+      contents: write
+      pull-requests: write
+      packages: write
+    uses: planningcenter/pco-release-action/.github/workflows/qa-release.yml@v1
+    secrets: inherit
+```
+
 ## Working on this Project
 
 - Build before pushing changes with `yarn build`


### PR DESCRIPTION
We want to be able to trigger a complete QA release that does everything in a simple way for our libraries. This shared action:

- creates a QA release
- publishes it
- deploys a protonova environment for all consuming apps.