### PR TITLE
chore: use github app instead of picobot token

### DIFF
--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -90,6 +90,8 @@ jobs:
       - name: Push to protonova branch for Consumers
         uses: planningcenter/pco-release-action/deploy@v1
         with:
+          app-id: ${{ secrets.PCO_DEPENDENCIES_APP_ID }}
+          private-key: ${{ secrets.PCO_DEPENDENCIES_PRIVATE_KEY }}
           ref: ${{ needs.create-qa-release.outputs.release-tag }}
           change-method: "merge"
           branch-name: "proto/${{ github.repository }}-${{ github.event.issue.number }}"

--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -90,7 +90,6 @@ jobs:
       - name: Push to protonova branch for Consumers
         uses: planningcenter/pco-release-action/deploy@v1
         with:
-          github-token: ${{ secrets.PICOBOT_JS_DEPLOYMENT }}
           ref: ${{ needs.create-qa-release.outputs.release-tag }}
           change-method: "merge"
           branch-name: "proto/${{ github.repository }}-${{ github.event.issue.number }}"

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -90,7 +90,6 @@ jobs:
       - name: Push to `staging` for Consumers
         uses: planningcenter/pco-release-action/deploy@v1
         with:
-          github-token: ${{ secrets.PICOBOT_JS_DEPLOYMENT }}
           ref: ${{ needs.create-rc-release.outputs.release-tag }}
           change-method: "merge"
           branch-name: "staging"

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -90,6 +90,8 @@ jobs:
       - name: Push to `staging` for Consumers
         uses: planningcenter/pco-release-action/deploy@v1
         with:
+          app-id: ${{ secrets.PCO_DEPENDENCIES_APP_ID }}
+          private-key: ${{ secrets.PCO_DEPENDENCIES_PRIVATE_KEY }}
           ref: ${{ needs.create-rc-release.outputs.release-tag }}
           change-method: "merge"
           branch-name: "staging"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,7 +86,6 @@ jobs:
       - name: Push to Consumers
         uses: planningcenter/pco-release-action/deploy@v1
         with:
-          github-token: ${{ secrets.PICOBOT_JS_DEPLOYMENT }}
           ref: ${{ needs.create-release.outputs.release-tag }}
           change-method: "pr"
           only: ${{ inputs.only }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -86,6 +86,8 @@ jobs:
       - name: Push to Consumers
         uses: planningcenter/pco-release-action/deploy@v1
         with:
+          app-id: ${{ secrets.PCO_DEPENDENCIES_APP_ID }}
+          private-key: ${{ secrets.PCO_DEPENDENCIES_PRIVATE_KEY }}
           ref: ${{ needs.create-release.outputs.release-tag }}
           change-method: "pr"
           only: ${{ inputs.only }}

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -30,6 +30,8 @@ jobs:
     steps:
       - uses: planningcenter/pco-release-action/deploy@v1
         with:
+          app-id: ${{ secrets.PCO_DEPENDENCIES_APP_ID }}
+          private-key: ${{ secrets.PCO_DEPENDENCIES_PRIVATE_KEY }}
           automerge: true
           upgrade-commands: '{"tapestry-react":"yarn tr upgrade"}' # this is assuming that you're upgrading
 ```

--- a/deploy/README.md
+++ b/deploy/README.md
@@ -30,7 +30,6 @@ jobs:
     steps:
       - uses: planningcenter/pco-release-action/deploy@v1
         with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
           automerge: true
           upgrade-commands: '{"tapestry-react":"yarn tr upgrade"}' # this is assuming that you're upgrading
 ```

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -1,9 +1,6 @@
 name: "PCO Release Deploy"
 description: "Deploys updates of a new release to all planningcenter repos that have a package as its dependency"
 inputs:
-  github-token:
-    description: "GitHub token for authentication"
-    required: true
   owner:
     description: "Owner of the repositories"
     required: false
@@ -48,6 +45,12 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Generate a token
+      id: generate-token
+      uses: actions/create-github-app-token@v1
+      with:
+        app-id: ${{ secrets.PCO_DEPENDENCIES_APP_ID }}
+        private-key: ${{ secrets.PCO_DEPENDENCIES_PRIVATE_KEY }}
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
@@ -87,7 +90,7 @@ runs:
       shell: bash
       run: bundle exec ruby ${{ github.action_path }}/run.rb
       env:
-        GITHUB_TOKEN: ${{ inputs.github-token }}
+        GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         PACKAGE_NAME: ${{ steps.find-package-name.outputs.package-name }}
         PACKAGE_VERSION: ${{ steps.find-version.outputs.version }}
         OWNER: ${{ inputs.owner }}

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -42,6 +42,12 @@ inputs:
     description: "The ref to use for the release"
     required: false
     default: ""
+  app-id:
+    description: "The app id for the github app"
+    required: true
+  private-key:
+    description: "The private key for the github app"
+    required: true
 runs:
   using: "composite"
   steps:
@@ -49,8 +55,8 @@ runs:
       id: generate-token
       uses: actions/create-github-app-token@v1
       with:
-        app-id: ${{ secrets.PCO_DEPENDENCIES_APP_ID }}
-        private-key: ${{ secrets.PCO_DEPENDENCIES_PRIVATE_KEY }}
+        app-id: ${{ inputs.app-id }}
+        private-key: ${{ inputs.private-key }}
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}


### PR DESCRIPTION
In order to fine grain tune our permissions, we want to use a Github app (`Planning Center Dependencies`) to authenticate our updates. This requires us to change the authentication logic.

Also, we no longer need to send in the github token as an argument so that input is removed.