### PR TITLE
feat(deploy): allow for reading config for deployment from consumer repos

### DIFF
--- a/deploy/README.md
+++ b/deploy/README.md
@@ -35,3 +35,16 @@ jobs:
           automerge: true
           upgrade-commands: '{"tapestry-react":"yarn tr upgrade"}' # this is assuming that you're upgrading
 ```
+
+## Config Files in Consumers
+
+Some consumers of the library will have specific commands that they need to use to upgrade to the newest version. Instead of making each library know that, you can add a config file to the consumer repo called `.pco-release.config.yml`.
+
+```yml
+# `./.pco-release.config.yml`
+upgrade_command: "yarn tr upgrade"
+```
+
+In this case, whenever upgrading, it will use the new upgrade command.
+
+This file is not necessary, but allows for customization.

--- a/deploy/spec/deployer/repo/base_updater_spec.rb
+++ b/deploy/spec/deployer/repo/base_updater_spec.rb
@@ -1,0 +1,80 @@
+describe Deployer::Repo::BaseUpdater do
+  describe "#upgrade_command" do
+    context "when there is a config file specifying a command" do
+      it "returns the command with replacements" do
+        config =
+          instance_double(
+            Deployer::Config,
+            version: "1.0.1",
+            package_name: "test"
+          )
+        updater = described_class.new("test", config: config)
+        allow(File).to receive(:exist?).and_return(true)
+        allow(YAML).to receive(:load_file).and_return(
+          "upgrade_command" =>
+            "some other upgrade --name={{package_name}} --version={{version}}"
+        )
+
+        expect(updater.send(:upgrade_command)).to eq(
+          "some other upgrade --name=test --version=1.0.1"
+        )
+      end
+    end
+
+    context "when there is a config, but no upgrade command" do
+      it "returns the default upgrade" do
+        config =
+          instance_double(
+            Deployer::Config,
+            version: "1.0.1",
+            package_name: "test",
+            upgrade_commands: {
+            }
+          )
+        updater = described_class.new("test", config: config)
+        allow(File).to receive(:exist?).and_return(true)
+        allow(YAML).to receive(:load_file).and_return({})
+
+        expect(updater.send(:upgrade_command)).to eq("yarn upgrade test@1.0.1")
+      end
+    end
+
+    context "when the config contains an upgrade command for the repo" do
+      it "returns the command " do
+        config =
+          instance_double(
+            Deployer::Config,
+            version: "1.0.1",
+            package_name: "test",
+            upgrade_commands: {
+              "test" => "some other upgrade"
+            }
+          )
+        updater = described_class.new("test", config: config)
+        allow(File).to receive(:exist?).and_return(false)
+
+        expect(updater.send(:upgrade_command)).to eq(
+          "some other upgrade test@1.0.1"
+        )
+      end
+    end
+
+    context "when the config contains an upgrade command for a different repo" do
+      it "returns the default upgrade" do
+        config =
+          instance_double(
+            Deployer::Config,
+            version: "1.0.1",
+            package_name: "test",
+            upgrade_commands: {
+              "other" => "some other upgrade"
+            }
+          )
+        updater = described_class.new("test", config: config)
+        allow(File).to receive(:exist?).and_return(false)
+
+        expect(updater.send(:upgrade_command)).to eq("yarn upgrade test@1.0.1")
+      end
+    end
+  end
+end


### PR DESCRIPTION
The `upgrade-commands` setting for deploys was a bit awkward.  It required each library to configure and know about the special upgrade needs of each library.  In addition, adding new specific settings (like enabling changelog updates) would be difficult.

This new feature reads a `.pco-release.config.yml` file at the root of consumer repos when deploying.  If there is a file, it will read it and use its configuration to override some settings.

Currently, this allows for specifying the `upgrade_command`, which it also uses string replacement to allow for specifying the version and package name.

For instance, tapestry-react will add the file like this:

```yml
upgrade_command: "yarn tr upgrade {{package_name}}@{{version}}"
```

In the future, I hope to also use the config for changelog update settings.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208217906306056