### PR TITLE
feat(deploy): prevent major versions from deploy

### DIFF
--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -99,3 +99,4 @@ jobs:
           exclude: ${{ inputs.exclude }}
           include: ${{ inputs.include }}
           upgrade-commands: ${{ inputs.upgrade-commands }}
+          allow-major: true

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -99,3 +99,4 @@ jobs:
           exclude: ${{ inputs.exclude }}
           include: ${{ inputs.include }}
           upgrade-commands: ${{ inputs.upgrade-commands }}
+          allow-major: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -94,3 +94,4 @@ jobs:
           exclude: ${{ inputs.exclude }}
           include: ${{ inputs.include }}
           upgrade-commands: ${{ inputs.upgrade-commands }}
+          allow-major: false

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -48,6 +48,10 @@ inputs:
   private-key:
     description: "The private key for the github app"
     required: true
+  allow-major:
+    description: "Allow major version updates"
+    required: false
+    default: false
 runs:
   using: "composite"
   steps:
@@ -107,4 +111,5 @@ runs:
         CHANGE_METHOD: ${{ inputs.change-method }}
         INCLUDE: ${{ inputs.include }}
         EXCLUDE: ${{ inputs.exclude }}
+        ALLOW_MAJOR: ${{ inputs.allow-major }}
       working-directory: ${{ github.action_path}}

--- a/deploy/lib/deployer.rb
+++ b/deploy/lib/deployer.rb
@@ -8,6 +8,7 @@ require_relative "deployer/repo"
 require_relative "deployer/repo/base_updater"
 require_relative "deployer/repo/merge_updater"
 require_relative "deployer/repo/pull_request_updater"
+require_relative "deployer/repo/version_compare"
 require_relative "deployer/repos"
 
 class Deployer

--- a/deploy/lib/deployer/config.rb
+++ b/deploy/lib/deployer/config.rb
@@ -11,7 +11,8 @@ class Deployer
       only: [],
       upgrade_commands: {},
       include: [],
-      exclude: []
+      exclude: [],
+      allow_major: false
     )
       @github_token = github_token
       @owner = owner
@@ -24,6 +25,7 @@ class Deployer
       @exclude = exclude
       @branch_name = branch_name
       @change_method = change_method
+      @allow_major = allow_major
     end
 
     attr_reader :github_token,
@@ -36,7 +38,8 @@ class Deployer
                 :upgrade_commands,
                 :include,
                 :exclude,
-                :change_method
+                :change_method,
+                :allow_major
 
     def client
       @client ||=
@@ -47,6 +50,10 @@ class Deployer
 
     def log(message)
       puts "[PCO-Release] #{message}"
+    end
+
+    def disable_for_major?
+      !allow_major
     end
   end
 end

--- a/deploy/lib/deployer/repo/base_updater.rb
+++ b/deploy/lib/deployer/repo/base_updater.rb
@@ -9,7 +9,9 @@ class Deployer
       end
 
       def run
-        make_changes
+        clone_repo
+        Dir.chdir(name) { make_changes if updatable? }
+        cleanup
       rescue StandardError => e
         cleanup
         raise e
@@ -70,6 +72,10 @@ class Deployer
           "git push origin #{branch_name} -f",
           error_class: PushBranchFailure
         )
+      end
+
+      def updatable?
+        !config.disable_for_major? || !VersionCompare.new(config).major_upgrade?
       end
 
       def cleanup

--- a/deploy/lib/deployer/repo/base_updater.rb
+++ b/deploy/lib/deployer/repo/base_updater.rb
@@ -10,7 +10,13 @@ class Deployer
 
       def run
         clone_repo
-        Dir.chdir(name) { make_changes if updatable? }
+        Dir.chdir(name) do
+          if updatable?
+            make_changes
+          else
+            log "Skipping major upgrade for #{name}"
+          end
+        end
         cleanup
       rescue StandardError => e
         cleanup

--- a/deploy/lib/deployer/repo/merge_updater.rb
+++ b/deploy/lib/deployer/repo/merge_updater.rb
@@ -8,13 +8,9 @@ class Deployer
       private
 
       def make_changes
-        clone_repo
-        Dir.chdir(name) do
-          create_branch
-          run_upgrade_command
-          commit_and_push_changes
-        end
-        cleanup
+        create_branch
+        run_upgrade_command
+        commit_and_push_changes
       end
 
       def branch_name

--- a/deploy/lib/deployer/repo/pull_request_updater.rb
+++ b/deploy/lib/deployer/repo/pull_request_updater.rb
@@ -10,15 +10,11 @@ class Deployer
       attr_reader :pr_number
 
       def make_changes
-        clone_repo
-        Dir.chdir(name) do
-          create_branch
-          run_upgrade_command
-          commit_and_push_changes
-          create_pr
-          automerge_pr
-        end
-        cleanup
+        create_branch
+        run_upgrade_command
+        commit_and_push_changes
+        create_pr
+        automerge_pr
       end
 
       def clone_suffix

--- a/deploy/lib/deployer/repo/version_compare.rb
+++ b/deploy/lib/deployer/repo/version_compare.rb
@@ -1,0 +1,33 @@
+class Deployer
+  class Repo
+    class VersionCompare
+      def initialize(package_name:, version:)
+        @version = Gem::Version.new(version)
+        @package_name = package_name
+      end
+
+      def major_upgrade?
+        return true if current_version.nil?
+
+        current_version.segments.first != version.segments.first
+      end
+
+      private
+
+      attr_reader :package_name, :version
+
+      def current_version
+        @current_version ||=
+          begin
+            current_version_string =
+              File.read("yarn.lock").match(
+                /\n#{package_name}@\d+\.\d+\.\d+:\n\s\sversion "(.+)"/
+              )[
+                1
+              ]
+            Gem::Version.new(current_version_string)
+          end
+      end
+    end
+  end
+end

--- a/deploy/run.rb
+++ b/deploy/run.rb
@@ -12,6 +12,7 @@ config =
     branch_name: ENV["BRANCH_NAME"],
     change_method: ENV["CHANGE_METHOD"],
     include: ENV["INCLUDE"].split(","),
-    exclude: ENV["EXCLUDE"].split(",")
+    exclude: ENV["EXCLUDE"].split(","),
+    allow_major: ENV["ALLOW_MAJOR"] == "true"
   )
 Deployer.new(config).run


### PR DESCRIPTION
We want to take a more manual approach to major version upgrades. This means that we want to check if we are attempting to do a major upgrade
and if so, abort the change.

This was important to do at a per consumer level so that apps that were behind for 1 reason or another would not be accidentally upgraded on a patch release shortly after a major release.