### PR TITLE
feat(release): add more robust reporting 

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -75,7 +75,7 @@ jobs:
       cache: ${{ inputs.cache }}
       build-directory: ${{ inputs.build-directory }}
       ref: ${{ needs.create-release.outputs.release-tag }}
-      prerelease: true
+      prerelease: false
   deploy-to-consumers:
     needs: [create-release, publish-to-npm]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,6 +2,10 @@ name: PCO-Release - Release Automation
 on:
   workflow_call:
     inputs:
+      pr-number:
+        description: "The PR number that triggered the release"
+        required: true
+        type: number
       install-command:
         description: "The script command to use to install the package's dependencies"
         required: false
@@ -82,8 +86,11 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    env:
+      PR_NUMBER: ${{ inputs.pr-number }}
     steps:
       - name: Push to Consumers
+        id: push-to-consumers
         uses: planningcenter/pco-release-action/deploy@v1
         with:
           app-id: ${{ secrets.PCO_DEPENDENCIES_APP_ID }}
@@ -95,3 +102,44 @@ jobs:
           include: ${{ inputs.include }}
           upgrade-commands: ${{ inputs.upgrade-commands }}
           allow-major: false
+      - name: Post results to original PR
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const results = JSON.parse(process.env.results_json);
+            const body = `## Release Automation Results
+
+            ${results.successful_repos.length > 0 ? "### PRs created" : ""}
+
+            ${results.successful_repos.map(repo => "- [" + repo.name + "](" + repo.pr_url + ")").join("\n")}
+
+            ${results.failed_repos.length > 0 ? "### PRs failed" : ""}
+
+            ${results.failed_repos.map(repo => "- " + repo.name + ": " + repo.message).join("\n")}
+
+            ### Next steps
+
+            Run the following command to approve all the PRs:
+
+            \`\`\`
+              ${results.successful_repos.map(repo => "gh pr review " + repo.pr_number + " -repo=planningcenter/" + repo.name + " -a").join("\n")}
+            \`\`\`
+
+            ### If you need to revert
+
+            - Go to the actions tab
+            - Click \`Revert\` on the left hand actions list
+            - Click to the \`Run workflow\` button on the right
+            - enter the last successful version and click \`Run workflow\`
+            `
+            github.rest.issues.createComment({
+              issue_number: process.env.PR_NUMBER,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+
+            if (results.failed_repos.length > 0) {
+              throw new Error("Some PRs failed to create");
+            }

--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -52,6 +52,9 @@ inputs:
     description: "Allow major version updates"
     required: false
     default: false
+outputs:
+  json:
+    description: "The json output of the upgrade prs."
 runs:
   using: "composite"
   steps:
@@ -98,6 +101,7 @@ runs:
         working-directory: ${{ github.action_path}}
     - name: Setup Upgrade PRs
       shell: bash
+      id: setup-upgrade-prs
       run: bundle exec ruby ${{ github.action_path }}/run.rb
       env:
         GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/deploy/lib/deployer.rb
+++ b/deploy/lib/deployer.rb
@@ -9,22 +9,24 @@ require_relative "deployer/repo/base_updater"
 require_relative "deployer/repo/merge_updater"
 require_relative "deployer/repo/pull_request_updater"
 require_relative "deployer/repo/version_compare"
+require_relative "deployer/reporter"
 require_relative "deployer/repos"
 
 class Deployer
   def initialize(config)
     @config = config
+    @failed_repos = []
+    @successful_repos = []
   end
 
   def run
-    log "Updating #{package_name} to #{version} in the following repositories: #{repos.map(&:name).join(", ")}"
-    failed_repos = []
+    log_deployer_start
     repos.each do |repo|
-      log "updating #{package_name} in #{repo.name}"
+      log_repo_start(repo)
       repo.update_package
-      log repo.success_message
+      handle_success(repo)
     rescue BaseError, StandardError => e
-      failed_repos.push(repo.name)
+      failed_repos.push(repo)
       log failure_message(error: e, repo: repo)
     end
     return unless failed_repos.any?
@@ -39,6 +41,18 @@ class Deployer
   private
 
   attr_reader :config
+  attr_accessor :failed_repos, :successful_repos
+
+  def report_results
+    return unless failed_repos.any?
+
+    raise "[PCO-Release]: Failed in the following repos:\n- #{failed_repos.map(&:name).join("\n- ")}"
+  end
+
+  def handle_success(repo)
+    log repo.success_message
+    successful_repos.push(repo)
+  end
 
   def failure_message(error:, repo:)
     "Failed to update #{package_name} in #{repo.name}: #{error.class} #{error.message}"
@@ -54,5 +68,13 @@ class Deployer
 
   def log(message)
     config.log(message)
+  end
+
+  def log_deployer_start
+    log "Updating #{package_name} to #{version} in the following repositories: #{repos.map(&:name).join(", ")}"
+  end
+
+  def log_repo_start(repo)
+    log "updating #{package_name} in #{repo.name}"
   end
 end

--- a/deploy/lib/deployer/errors.rb
+++ b/deploy/lib/deployer/errors.rb
@@ -1,20 +1,41 @@
 class Deployer
   class BaseError < StandardError
+    def initialize(message = nil)
+      super(message ? "[#{friendly_name}]: #{message}" : self.class.name)
+    end
+
+    private
+
+    def friendly_name
+      self.class.name
+    end
   end
 
   class FailedToCloneRepo < BaseError
   end
 
   class CreateBranchFailure < BaseError
+    def friendly_name
+      "Create Branch Failure"
+    end
   end
 
   class UpgradeCommandFailure < BaseError
+    def friendly_name
+      "Failed While Running Upgrade Command"
+    end
   end
 
   class CommitChangesFailure < BaseError
+    def friendly_name
+      "Failed To Commit Changes"
+    end
   end
 
   class PushBranchFailure < BaseError
+    def friendly_name
+      "Push Branch Failure"
+    end
   end
 
   class FailedToCreatePRError < BaseError

--- a/deploy/lib/deployer/repo.rb
+++ b/deploy/lib/deployer/repo.rb
@@ -1,26 +1,50 @@
 class Deployer
   class Repo
-    def initialize(name, config:)
+    def initialize(name, config:, updater: nil)
       @name = name
       @config = config
+      @updater = updater || default_updater
     end
 
     def update_package
       updater.run
+
+      self.success = true
+    rescue StandardError => e
+      self.error_message = e.message
+      self.success = false
     end
 
     def success_message
-      "Successfully updated #{package_name} to #{version} in #{name}#{updater.message_suffix}"
+      "Successfully updated #{package_name} to #{version} in #{name}"
     end
 
-    attr_reader :name
+    def pr_number
+      updater.pr_number
+    end
+
+    def pr_url
+      updater.pr_url
+    end
+
+    def success?
+      success
+    end
+
+    def failure?
+      !success?
+    end
+
+    attr_reader :name, :error_message
 
     private
 
-    attr_reader :config
+    attr_reader :config, :updater
+    attr_accessor :success
+    attr_writer :error_message
 
-    def updater
-      @updater ||= updater_class.new(name, config: config)
+    def default_updater
+      updater_class.new(name, config: config)
     end
 
     def updater_class

--- a/deploy/lib/deployer/repo/base_updater.rb
+++ b/deploy/lib/deployer/repo/base_updater.rb
@@ -10,13 +10,7 @@ class Deployer
 
       def run
         clone_repo
-        Dir.chdir(name) do
-          if updatable?
-            make_changes
-          else
-            log "Skipping major upgrade for #{name}"
-          end
-        end
+        Dir.chdir(name) { make_changes_if_updatable }
         cleanup
       rescue StandardError => e
         cleanup
@@ -37,6 +31,14 @@ class Deployer
 
       def branch_name
         raise NotImplementedError
+      end
+
+      def make_changes_if_updatable
+        if updatable?
+          make_changes
+        else
+          log "Skipping major upgrade for #{name}"
+        end
       end
 
       def clone_repo

--- a/deploy/lib/deployer/repo/base_updater.rb
+++ b/deploy/lib/deployer/repo/base_updater.rb
@@ -17,6 +17,15 @@ class Deployer
         raise e
       end
 
+      def pr_number
+      end
+
+      def pr_url
+        return if pr_number.nil?
+
+        "https://github.com/#{owner}/#{name}/pull/#{pr_number}"
+      end
+
       protected
 
       attr_reader :name, :config

--- a/deploy/lib/deployer/repo/merge_updater.rb
+++ b/deploy/lib/deployer/repo/merge_updater.rb
@@ -1,10 +1,6 @@
 class Deployer
   class Repo
     class MergeUpdater < BaseUpdater
-      def message_suffix
-        ""
-      end
-
       private
 
       def make_changes

--- a/deploy/lib/deployer/repo/pull_request_updater.rb
+++ b/deploy/lib/deployer/repo/pull_request_updater.rb
@@ -1,13 +1,11 @@
 class Deployer
   class Repo
     class PullRequestUpdater < BaseUpdater
-      def message_suffix
-        " (https://github.com/#{owner}/#{name}/pull/#{pr_number})"
-      end
+      attr_reader :pr_number
 
       private
 
-      attr_reader :pr_number
+      attr_writer :pr_number
 
       def make_changes
         create_branch
@@ -37,7 +35,7 @@ class Deployer
           )
         raise FailedToCreatePRError, response if response.number.nil?
 
-        @pr_number = response.number
+        self.pr_number = response.number
       end
 
       def automerge_pr

--- a/deploy/lib/deployer/reporter.rb
+++ b/deploy/lib/deployer/reporter.rb
@@ -1,0 +1,45 @@
+require "shellwords"
+
+class Deployer
+  class Reporter
+    def initialize(repos)
+      @repos = repos
+    end
+
+    attr_reader :repos
+
+    def to_json(_opts = {})
+      {
+        failed_repos:
+          failed_repos.map do |repo|
+            { name: repo.name, message: repo.error_message }
+          end,
+        successful_repos:
+          successful_repos.map do |repo|
+            { name: repo.name, pr_number: repo.pr_number, pr_url: repo.pr_url }
+          end
+      }.to_json
+    end
+
+    def output_to_github
+      output_messages.each do |message|
+        # I have tried for hours to get this to go to the output, but it never works.  Using env instead.
+        system("echo #{Shellwords.escape(message)} >> $GITHUB_ENV")
+      end
+    end
+
+    private
+
+    def output_messages
+      ["results_json=#{to_json}"]
+    end
+
+    def failed_repos
+      repos.select(&:failure?)
+    end
+
+    def successful_repos
+      repos.select(&:success?)
+    end
+  end
+end

--- a/deploy/run.rb
+++ b/deploy/run.rb
@@ -15,4 +15,6 @@ config =
     exclude: ENV["EXCLUDE"].split(","),
     allow_major: ENV["ALLOW_MAJOR"] == "true"
   )
-Deployer.new(config).run
+reporter = Deployer.new(config).run
+
+reporter.output_to_github

--- a/deploy/spec/deployer/repo_spec.rb
+++ b/deploy/spec/deployer/repo_spec.rb
@@ -1,0 +1,110 @@
+describe Deployer::Repo do
+  let(:config) do
+    instance_double(
+      Deployer::Config,
+      package_name: "test-pkg",
+      version: "1.2.7"
+    )
+  end
+
+  describe "#failure?" do
+    it "returns false if the repo update is successful" do
+      updater = instance_double(Deployer::Repo::MergeUpdater, run: nil)
+      repo = described_class.new("test", config: config, updater: updater)
+
+      repo.update_package
+
+      expect(repo.failure?).to be false
+    end
+
+    it "returns true when updater raises an error" do
+      updater = instance_double(Deployer::Repo::MergeUpdater)
+      allow(updater).to receive(:run).and_raise(StandardError)
+      repo = described_class.new("test", config: config, updater: updater)
+
+      repo.update_package
+
+      expect(repo.failure?).to be true
+    end
+  end
+
+  describe "#success?" do
+    it "returns true if the repo update is successful" do
+      updater = instance_double(Deployer::Repo::MergeUpdater, run: nil)
+      repo = described_class.new("test", config: config, updater: updater)
+
+      repo.update_package
+
+      expect(repo.success?).to be true
+    end
+
+    it "returns false when updater raises an error" do
+      updater = instance_double(Deployer::Repo::MergeUpdater)
+      allow(updater).to receive(:run).and_raise(StandardError)
+      repo = described_class.new("test", config: config, updater: updater)
+
+      repo.update_package
+
+      expect(repo.success?).to be false
+    end
+  end
+
+  describe "#error_message" do
+    it "returns nothing when successful" do
+      updater = instance_double(Deployer::Repo::MergeUpdater, run: true)
+      repo = described_class.new("test", config: config, updater: updater)
+
+      repo.update_package
+
+      expect(repo.error_message).to be_nil
+    end
+
+    it "returns the error message when failed" do
+      updater = instance_double(Deployer::Repo::MergeUpdater, run: false)
+      repo = described_class.new("test", config: config, updater: updater)
+      allow(updater).to receive(:run).and_raise(
+        Deployer::PushBranchFailure,
+        "You don't have permissions to push to this branch"
+      )
+
+      repo.update_package
+
+      expect(
+        repo.error_message
+      ).to eq "[Push Branch Failure]: You don't have permissions to push to this branch"
+    end
+  end
+
+  describe "#success_message" do
+    it "returns a success message" do
+      updater = instance_double(Deployer::Repo::MergeUpdater)
+      repo = described_class.new("test", config: config, updater: updater)
+
+      expect(
+        repo.success_message
+      ).to eq "Successfully updated test-pkg to 1.2.7 in test"
+    end
+  end
+
+  describe "#pr_number" do
+    it "returns the PR number" do
+      updater = instance_double(Deployer::Repo::MergeUpdater, pr_number: 123)
+      repo = described_class.new("test", config: config, updater: updater)
+
+      expect(repo.pr_number).to eq 123
+    end
+  end
+
+  describe "#pr_url" do
+    it "returns the PR URL" do
+      updater =
+        instance_double(
+          Deployer::Repo::MergeUpdater,
+          pr_url: "http://github.com/org/repo/pull/123"
+        )
+      repo = described_class.new("test", config: config, updater: updater)
+
+      expect(repo.pr_url).to eq "http://github.com/org/repo/pull/123"
+    end
+  end
+end

--- a/deploy/spec/deployer/reporter_spec.rb
+++ b/deploy/spec/deployer/reporter_spec.rb
@@ -1,0 +1,46 @@
+describe Deployer::Reporter do
+  let(:failed_repo) do
+    instance_double(
+      Deployer::Repo,
+      name: "test",
+      error_message: "Missing permissions.",
+      failure?: true,
+      success?: false
+    )
+  end
+  let(:successful_repo) do
+    instance_double(
+      Deployer::Repo,
+      name: "test2",
+      pr_number: 127,
+      pr_url: "http://github.com/org/repo/pull/127",
+      failure?: false,
+      success?: true
+    )
+  end
+
+  describe "#to_json" do
+    it "returns a json representation of the report" do
+      report = described_class.new([failed_repo, successful_repo])
+
+      expect(report.to_json).to eq(
+        failed_repos: [{ name: "test", message: "Missing permissions." }],
+        successful_repos: [
+          {
+            name: "test2",
+            pr_number: 127,
+            pr_url: "http://github.com/org/repo/pull/127"
+          }
+        ]
+      )
+    end
+  end
+
+  describe "#output_messages" do
+    it "returns the code to set up the proper outputs" do
+      report = described_class.new([failed_repo, successful_repo])
+
+      expect(report.send(:output_messages)).to eq(["json=#{report.to_json}"])
+    end
+  end
+end

--- a/deploy/spec/deployer_spec.rb
+++ b/deploy/spec/deployer_spec.rb
@@ -90,7 +90,7 @@ describe Deployer do
       allow(config).to receive(:log)
       described_class.new(config).run
       expect(config).to have_received(:log).with(
-        "Successfully updated @planningcenter/tapestry-react to 1.0.1 in topbar (https://github.com/planningcenter/topbar/pull/1)"
+        "Successfully updated @planningcenter/tapestry-react to 1.0.1 in topbar"
       )
     end
 


### PR DESCRIPTION
Because we're not organizationally at a place where we are ready to auto-deploy without any checks, we need to make sure that there is clear communication about the "next steps" after a release is created.  In addition, we want to add clear communication about successes and points of failure.

This PR overhauls the reporting system, bringing it more out of github actions and into a report that shows up on the PR after it is complete.

Here is an example from one of my tests: https://github.com/planningcenter/test-js-auto-deploy-pkg/pull/5

![Screenshot 2024-09-09 at 2 09 06 PM](https://github.com/user-attachments/assets/fa566846-0e0f-4d10-a23a-f6a1b3610ac9)

It shows:

- The successful PRs that are created
- Any PRs that failed to create (and what repo they were in)
- A copyable command line command to approve all the PRs created (this is a great way to track who triggered the update so that they can be a point of contact if further action needs to happen).
- Clear instructions on how to revert the changes if something goes wrong.