### PR TITLE
feat(rc): add better reporting

### DIFF
--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -113,3 +113,9 @@ jobs:
           upgrade-commands: ${{ inputs.upgrade-commands }}
           allow-major: true
           package-json-path: ${{ inputs.package-json-path }}
+      - name: Post results to original PR
+        uses: planningcenter/pco-release-action/rc-reporting@v1
+        with:
+          pr-number: ${{ github.event.issue.number }}
+          results-json: ${{ env.results_json }}
+          actor: ${{ github.actor }}

--- a/rc-reporting/action.yml
+++ b/rc-reporting/action.yml
@@ -28,7 +28,7 @@ runs:
 
           ${successfulRepoList}
 
-          ${results.failed_repos.length > 0 ? "### Failed to deploy in the following repos" : ""}
+          ${results.failed_repos.length > 0 ? "### Failed to deploy in the following repos:" : ""}
 
           ${failedRepoList}
 

--- a/rc-reporting/action.yml
+++ b/rc-reporting/action.yml
@@ -1,0 +1,46 @@
+name: Post results to original PR
+inputs:
+  results-json:
+    description: "JSON string of results"
+    required: true
+  pr-number:
+    description: "The PR number that triggered the release"
+    required: true
+  actor:
+    description: "The actor that triggered the release"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/github-script@v7
+      env:
+        PR_NUMBER: ${{ inputs.pr-number }}
+        RESULTS_JSON: ${{ inputs.results-json }}
+        ACTOR: ${{ inputs.actor }}
+      with:
+        script: |
+          const results = JSON.parse(process.env.RESULTS_JSON);
+          const successfulRepoList = results.successful_repos.map(repo => `- \`${repo.name}\``).join("\n")
+          const failedRepoList = results.failed_repos.map(repo => `- \`${repo.name}\`: ${repo.message}`).join("\n")
+          const body = `## RC successfully created
+
+          ${results.successful_repos.length > 0 ? "### Deployed Successfully to the following repos:" : ""}
+
+          ${successfulRepoList}
+
+          ${results.failed_repos.length > 0 ? "### Failed to deploy in the following repos" : ""}
+
+          ${failedRepoList}
+
+          Triggered by: @${process.env.ACTOR}
+          `
+          github.rest.issues.createComment({
+            issue_number: process.env.PR_NUMBER,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: body
+          });
+
+          if (results.failed_repos.length > 0) {
+            throw new Error("Failed to push to all apps.");
+          }


### PR DESCRIPTION
Currently, when an `rc` build is triggered, it is unclear the results of how it goes out to all the apps.  This adds a report to the PR that triggered the rc release that looks like this:

![Screenshot 2024-09-18 at 10 17 01 AM](https://github.com/user-attachments/assets/afe877a9-766e-4433-88f8-6b62c9598896)


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208313553826159