### PR TITLE
feat(qa): improve reporting

### DIFF
--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -113,3 +113,10 @@ jobs:
           upgrade-commands: ${{ inputs.upgrade-commands }}
           allow-major: true
           package-json-path: ${{ inputs.package-json-path }}
+      - name: Post results to original PR
+        uses: planningcenter/pco-release-action/qa-reporting@v1
+        with:
+          pr-number: ${{ github.event.issue.number }}
+          results-json: ${{ env.results_json }}
+          actor: ${{ github.actor }}
+          proto-tag: "${{ github.repository }}-${{ github.event.issue.number }}"

--- a/create-qa-release/action.yml
+++ b/create-qa-release/action.yml
@@ -100,9 +100,3 @@ runs:
         commit: ${{ env.RELEASE_NAME}}
         generateReleaseNotes: true
         bodyFile: release_notes.md
-    - name: Comment Release URL
-      shell: bash
-      run: |
-        gh pr comment ${{ github.event.issue.number }} -b "[PCO-Release] [**Release ${{ env.new_version }} created**](${{ steps.create-release.outputs.html_url }})"
-      env:
-        GITHUB_TOKEN: ${{ inputs.GITHUB_TOKEN }}

--- a/qa-reporting/action.yml
+++ b/qa-reporting/action.yml
@@ -1,0 +1,52 @@
+name: Post results to original PR
+inputs:
+  results-json:
+    description: "JSON string of results"
+    required: true
+  pr-number:
+    description: "The PR number that triggered the release"
+    required: true
+  actor:
+    description: "The actor that triggered the release"
+    required: true
+  proto-tag:
+    description: "The tag of the proto release"
+    required: true
+runs:
+  using: "composite"
+  steps:
+    - uses: actions/github-script@v7
+      env:
+        PR_NUMBER: ${{ inputs.pr-number }}
+        RESULTS_JSON: ${{ inputs.results-json }}
+        ACTOR: ${{ inputs.actor }}
+        PROTO_TAG: ${{ inputs.proto-tag }}
+      with:
+        script: |
+          const results = JSON.parse(process.env.RESULTS_JSON);
+          const successfulRepoList = results.successful_repos.map(repo => `- \`${repo.name}\``).join("\n")
+          const failedRepoList = results.failed_repos.map(repo => `- \`${repo.name}\`: ${repo.message}`).join("\n")
+          const body = `## QA release successfully created
+
+          You can access the proto release at: https://${process.env.PROTO_TAG}.login.planningcenter.ninja/
+
+          ${results.successful_repos.length > 0 ? "### Deployed Successfully to the following repos:" : ""}
+
+          ${successfulRepoList}
+
+          ${results.failed_repos.length > 0 ? "### Failed to deploy in the following repos:" : ""}
+
+          ${failedRepoList}
+
+          Triggered by: @${process.env.ACTOR}
+          `
+          github.rest.issues.createComment({
+            issue_number: process.env.PR_NUMBER,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            body: body
+          });
+
+          if (results.failed_repos.length > 0) {
+            throw new Error("Failed to push to all apps.");
+          }


### PR DESCRIPTION
This improves the reporting to follow a similar reporting structure as #19 . After a qa release is processed, it creates a comment on the PR that triggered it with the following information:

- list of successful repos that it deployed to
- list of repos that it failed to deploy to (and the error message)
- A link to the protonova environment that was triggered
- A tag of the person who triggered the qa release 