### PR TITLE
fix: determine actual sha for cache key

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -54,7 +54,20 @@ on:
         default: ""
 
 jobs:
+  cache-key:
+    runs-on: ubuntu-latest
+    outputs:
+      key: ${{inputs.build-directory}}-${{ steps.get-sha.outputs.sha }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.ref }}
+      - id: get-sha
+        run: |
+          echo "sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
+
   build-and-test:
+    needs: cache-key
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -71,10 +84,10 @@ jobs:
         uses: actions/cache/save@v3
         with:
           path: ${{ inputs.build-directory }}
-          key: ${{inputs.build-directory }}-${{ github.sha }}
+          key: ${{ needs.cache-key.outputs.key }}
 
   publish-to-npm:
-    needs: build-and-test
+    needs: [cache-key, build-and-test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -90,7 +103,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: ${{ inputs.build-directory }}
-          key: ${{inputs.build-directory }}-${{ github.sha }}
+          key: ${{ needs.cache-key.outputs.key }}
       - run: ${{ inputs.install-command }}
       - name: Publish release to NPM
         if: ${{ !inputs.prerelease }}
@@ -104,7 +117,7 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.PLANNINGCENTER_NPM_TOKEN }}
 
   publish-to-github-package-registry:
-    needs: build-and-test
+    needs: [cache-key, build-and-test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -120,7 +133,7 @@ jobs:
         uses: actions/cache/restore@v3
         with:
           path: ${{ inputs.build-directory }}
-          key: ${{inputs.build-directory }}-${{ github.sha }}
+          key: ${{ needs.cache-key.outputs.key }}
       - run: ${{ inputs.install-command }}
         env:
           NPM_CONFIG_USERCONFIG: "" # let's continue to use the default registry for install


### PR DESCRIPTION
There was a bug that was happening when building multiple qa releases when `main` remained the same.  The reason for this is that the cache key was based around the `github.sha`.  This is fine when it is triggered by a normal sha, but comments triggering a run actually are run from the `sha` of `main`.  This means that the build directory is cached for ANY qa build going into `main` and it will restore from that point until `main` is a new sha.  An [example of this occurred in add-ons](https://github.com/planningcenter/add-ons-js/actions/runs/10964128584/job/30447122150#step:7:8).

To fix this, we are detecting the actual sha that we're using from the release that we built.