### PR TITLE
fix: ensure file fetcher successfully returns

### DIFF
--- a/deploy/lib/deployer/repo/dependabot_pull_request_updater.rb
+++ b/deploy/lib/deployer/repo/dependabot_pull_request_updater.rb
@@ -38,6 +38,7 @@ class Deployer
                 credentials: credentials
               )
             sanitize_yarnrc_yml(fetcher)
+            fetcher
           end
       end
 


### PR DESCRIPTION
After making adjustments for apps that use a vendored version of yarn 3, there was a bug that popped up because the return of the `fetcher` was no longer the fetcher.

In order to fix this, I just ensured that we returned the fetcher after sanitizing the yarnrc.

Fixes #24 