### PR TITLE
feat(sync-with-labels): make cache configurable

### DIFF
--- a/sync-with-labels/action.yml
+++ b/sync-with-labels/action.yml
@@ -5,6 +5,11 @@ inputs:
   GITHUB_TOKEN:
     description: token for access
     required: true
+  cache:
+    description: "Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm, or '' for no caching."
+    required: false
+    type: string
+    default: "yarn"
   package_json_path:
     description: "The path to the package.json file to version."
     required: false
@@ -23,7 +28,7 @@ runs:
       if: ${{ github.event.pull_request.head.ref == 'pco-release--internal' && (github.event.label.name == 'pco-release-patch' || github.event.label.name == 'pco-release-minor' || github.event.label.name == 'pco-release-major') }}
       with:
         node-version: "20"
-        cache: "yarn"
+        cache: ${{ inputs.cache }}
     - uses: planningcenter/pco-release-action/release-by-pr@v1
       if: ${{ github.event.pull_request.head.ref == 'pco-release--internal' && (github.event.label.name == 'pco-release-patch' || github.event.label.name == 'pco-release-minor' || github.event.label.name == 'pco-release-major') }}
       with:


### PR DESCRIPTION
We'd like to use the `sync-with-labels` action in [@planningcenter/add-ons-cli](https://github.com/planningcenter/add-ons-cli), but that package uses `npm`, and the action currently hardcodes `yarn`.

