### PR TITLE
fix: disable yarn version download prompt

### DIFF
--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -78,7 +78,7 @@ runs:
         node-version: "18"
     - name: Enable Corepack
       shell: bash
-      run: corepack enable
+      run: export COREPACK_ENABLE_DOWNLOAD_PROMPT=0 && corepack enable
     - name: Find new version
       id: find-version
       shell: bash


### PR DESCRIPTION
Because corepack has a confirmation for downloading the yarn version, it was causing failures.  This skips that confirmation and allows the yarn version to download automatically.