### PR TITLE
feat: raise errors when versions are not supported

### DIFF
--- a/deploy/lib/deployer/errors.rb
+++ b/deploy/lib/deployer/errors.rb
@@ -46,4 +46,16 @@ class Deployer
 
   class VersionCompareFailure < BaseError
   end
+
+  class RequirementsNotMet < BaseError
+    def initialize(version)
+      super(build_message(version))
+    end
+
+    def build_message(version)
+      "Upgrade does not satisfy requirements. The latest upgradable verison is #{version}. " \
+        "Verify that the requirement allows for an upgrade to this version and check that all " \
+        "peer dependencies are satisfied."
+    end
+  end
 end

--- a/deploy/lib/deployer/repo/dependabot_pull_request_updater.rb
+++ b/deploy/lib/deployer/repo/dependabot_pull_request_updater.rb
@@ -5,6 +5,7 @@ class Deployer
     class DependabotPullRequestUpdater < PullRequestUpdater
       def run
         setup_runner
+        verify_upgrade_satisfies
         create_pr
         automerge_pr if config.automerge
       end
@@ -197,6 +198,18 @@ class Deployer
 
         yarnrc_yml_file.content =
           yarnrc_yml_file.content.gsub("yarnPath:", "# yarnPath:")
+      end
+
+      def verify_upgrade_satisfies
+        if Gem::Version.new(resolvable_version) >= Gem::Version.new(version)
+          return
+        end
+
+        raise RequirementsNotMet, resolvable_version
+      end
+
+      def resolvable_version
+        checker.latest_resolvable_version
       end
     end
   end


### PR DESCRIPTION
There were scenarios where an upgrade was not compatible because of peerDependencies not being valid.  This caused the version to be upgraded to a lower version than what we intended.  Instead of allowing that to happen, we will now raise an error that communicates why we were not able to upgrade to the newer version.

Fixes #26 