### PR TITLE
feat: open `deploy` to take package-names

### DIFF
--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -56,6 +56,9 @@ inputs:
     description: "path to package.json"
     required: false
     default: "package.json"
+  package-names:
+    description: "The names of the packages to update"
+    required: false
 outputs:
   json:
     description: "The json output of the upgrade prs."
@@ -72,6 +75,7 @@ runs:
     - uses: actions/checkout@v4
       with:
         ref: ${{ inputs.ref }}
+        fetch-depth: 0
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
@@ -89,6 +93,7 @@ runs:
         fi
         echo "version=$VERSION" >> $GITHUB_OUTPUT
     - name: Find package_name
+      if: ${{ !inputs.package-names }}
       id: find-package-name
       shell: bash
       run: |
@@ -113,6 +118,7 @@ runs:
       run: bundle exec ruby ${{ github.action_path }}/run.rb
       env:
         GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
+        PACKAGE_NAMES: ${{ inputs.package-names }}
         PACKAGE_NAME: ${{ steps.find-package-name.outputs.package-name }}
         PACKAGE_VERSION: ${{ steps.find-version.outputs.version }}
         OWNER: ${{ inputs.owner }}

--- a/deploy/lib/deployer.rb
+++ b/deploy/lib/deployer.rb
@@ -42,11 +42,13 @@ class Deployer
   def report_results
     return unless failed_repos.any?
 
-    raise "[PCO-Release]: Failed in the following repos:\n- #{failed_repos.map(&:name).join("\n- ")}"
+    failed_repos_list =
+      failed_repos.map { |r| "#{r.name}: #{r.package_name}" }.join("\n- ")
+    raise "[PCO-Release]: Failed in the following repos:\n- #{failed_repos_list}"
   end
 
-  def package_name
-    config.package_name
+  def package_names
+    config.package_names
   end
 
   def version
@@ -58,18 +60,22 @@ class Deployer
   end
 
   def log_deployer_start
-    log "Updating #{package_name} to #{version} in the following repositories: #{repos.map(&:name).join(", ")}"
+    log "Updating #{package_names.join(", ")} to #{version} in the following repositories: #{repo_names.join(", ")}"
   end
 
   def log_repo_start(repo)
-    log "updating #{package_name} in #{repo.name}"
+    log "updating #{repo.package_name} in #{repo.name}"
   end
 
   def log_result(repo)
     if repo.success?
       log repo.success_message
     else
-      log "Failed to update #{package_name} in #{repo.name}: #{repo.error_message}"
+      log "Failed to update #{repo.package_name} in #{repo.name}: #{repo.error_message}"
     end
+  end
+
+  def repo_names
+    repos.map(&:name).uniq
   end
 end

--- a/deploy/lib/deployer/config.rb
+++ b/deploy/lib/deployer/config.rb
@@ -3,8 +3,8 @@ class Deployer
     def initialize( # rubocop:disable Metrics/ParameterLists, Metrics/MethodLength
       github_token:,
       owner:,
-      package_name:,
       version:,
+      package_names:,
       change_method: "pr",
       branch_name: "main",
       automerge: false,
@@ -16,7 +16,6 @@ class Deployer
     )
       @github_token = github_token
       @owner = owner
-      @package_name = package_name
       @version = version
       @automerge = automerge
       @only = only
@@ -26,11 +25,12 @@ class Deployer
       @branch_name = branch_name
       @change_method = change_method
       @allow_major = allow_major
+      @package_names = package_names
     end
 
     attr_reader :github_token,
                 :owner,
-                :package_name,
+                :package_names,
                 :version,
                 :automerge,
                 :branch_name,

--- a/deploy/lib/deployer/repo.rb
+++ b/deploy/lib/deployer/repo.rb
@@ -1,8 +1,9 @@
 class Deployer
   class Repo
-    def initialize(name, config:, updater: nil)
+    def initialize(name, package_name:, config:, updater: nil)
       @name = name
       @config = config
+      @package_name = package_name
       @updater = updater || default_updater
     end
 
@@ -35,7 +36,7 @@ class Deployer
       !success?
     end
 
-    attr_reader :name, :error_message
+    attr_reader :name, :error_message, :package_name
 
     private
 
@@ -44,7 +45,7 @@ class Deployer
     attr_writer :error_message
 
     def default_updater
-      updater_class.new(name, config: config)
+      updater_class.new(name, config: config, package_name: package_name)
     end
 
     def updater_class
@@ -56,10 +57,6 @@ class Deployer
       else
         DependabotPullRequestUpdater
       end
-    end
-
-    def package_name
-      config.package_name
     end
 
     def version

--- a/deploy/lib/deployer/repo/base_updater.rb
+++ b/deploy/lib/deployer/repo/base_updater.rb
@@ -3,9 +3,10 @@ require "yaml"
 class Deployer
   class Repo
     class BaseUpdater
-      def initialize(name, config:)
+      def initialize(name, config:, package_name:)
         @name = name
         @config = config
+        @package_name = package_name
       end
 
       def run
@@ -28,7 +29,7 @@ class Deployer
 
       protected
 
-      attr_reader :name, :config
+      attr_reader :name, :config, :package_name
 
       def make_changes
         raise NotImplementedError
@@ -132,10 +133,6 @@ class Deployer
 
       def owner
         config.owner
-      end
-
-      def package_name
-        config.package_name
       end
 
       def version

--- a/deploy/lib/deployer/reporter.rb
+++ b/deploy/lib/deployer/reporter.rb
@@ -9,6 +9,10 @@ class Deployer
     attr_reader :repos
 
     def to_json(_opts = {})
+      as_json.to_json
+    end
+
+    def as_json(_opts = {})
       {
         failed_repos:
           failed_repos.map do |repo|
@@ -18,7 +22,7 @@ class Deployer
           successful_repos.map do |repo|
             { name: repo.name, pr_number: repo.pr_number, pr_url: repo.pr_url }
           end
-      }.to_json
+      }
     end
 
     def output_to_github

--- a/deploy/run.rb
+++ b/deploy/run.rb
@@ -1,20 +1,29 @@
 require_relative "./lib/deployer"
 
-config =
-  Deployer::Config.new(
-    github_token: ENV["GITHUB_TOKEN"],
-    package_name: ENV["PACKAGE_NAME"],
-    version: ENV["PACKAGE_VERSION"],
-    owner: ENV["OWNER"],
-    only: ENV["ONLY"].split(","),
-    automerge: ENV["AUTOMERGE"] == "true",
-    upgrade_commands: JSON.parse(ENV["UPGRADE_COMMANDS"]),
-    branch_name: ENV["BRANCH_NAME"],
-    change_method: ENV["CHANGE_METHOD"],
-    include: ENV["INCLUDE"].split(","),
-    exclude: ENV["EXCLUDE"].split(","),
-    allow_major: ENV["ALLOW_MAJOR"] == "true"
-  )
-reporter = Deployer.new(config).run
+COMMON_CONFIG = {
+  github_token: ENV["GITHUB_TOKEN"],
+  version: ENV["PACKAGE_VERSION"],
+  owner: ENV["OWNER"],
+  only: ENV["ONLY"].split(","),
+  automerge: ENV["AUTOMERGE"] == "true",
+  upgrade_commands: JSON.parse(ENV["UPGRADE_COMMANDS"]),
+  branch_name: ENV["BRANCH_NAME"],
+  change_method: ENV["CHANGE_METHOD"],
+  include: ENV["INCLUDE"].split(","),
+  exclude: ENV["EXCLUDE"].split(","),
+  allow_major: ENV["ALLOW_MAJOR"] == "true"
+}
 
-reporter.output_to_github
+def run_for_packages
+  config = Deployer::Config.new(**COMMON_CONFIG, package_names: package_names)
+  reporter = Deployer.new(config).run
+  reporter.output_to_github
+end
+
+def package_names
+  return ENV["PACKAGE_NAMES"].split(",") if ENV["PACKAGE_NAMES"]
+
+  [ENV["PACKAGE_NAME"]]
+end
+
+run_for_packages

--- a/deploy/spec/deployer/config_spec.rb
+++ b/deploy/spec/deployer/config_spec.rb
@@ -4,13 +4,13 @@ describe Deployer::Config do
       Deployer::Config.new(
         github_token: "",
         owner: "planningcenter",
-        package_name: "@planningcenter/tapestry-react",
+        package_names: ["@planningcenter/tapestry-react"],
         version: "1.0.1"
       )
 
     expect(config.github_token).to eq("")
     expect(config.owner).to eq("planningcenter")
-    expect(config.package_name).to eq("@planningcenter/tapestry-react")
+    expect(config.package_names).to eq(["@planningcenter/tapestry-react"])
     expect(config.version).to eq("1.0.1")
     expect(config.automerge).to eq(false)
     expect(config.only).to eq([])

--- a/deploy/spec/deployer/repo/base_updater_spec.rb
+++ b/deploy/spec/deployer/repo/base_updater_spec.rb
@@ -6,9 +6,10 @@ describe Deployer::Repo::BaseUpdater do
           instance_double(
             Deployer::Config,
             version: "1.0.1",
-            package_name: "test"
+            package_names: ["test"]
           )
-        updater = described_class.new("test", config: config)
+        updater =
+          described_class.new("repo", config: config, package_name: "test")
         allow(File).to receive(:exist?).and_return(true)
         allow(YAML).to receive(:load_file).and_return(
           "upgrade_command" =>
@@ -27,11 +28,12 @@ describe Deployer::Repo::BaseUpdater do
           instance_double(
             Deployer::Config,
             version: "1.0.1",
-            package_name: "test",
+            package_names: ["test"],
             upgrade_commands: {
             }
           )
-        updater = described_class.new("test", config: config)
+        updater =
+          described_class.new("repo", config: config, package_name: "test")
         allow(File).to receive(:exist?).and_return(true)
         allow(YAML).to receive(:load_file).and_return({})
 
@@ -45,12 +47,13 @@ describe Deployer::Repo::BaseUpdater do
           instance_double(
             Deployer::Config,
             version: "1.0.1",
-            package_name: "test",
+            package_names: ["test"],
             upgrade_commands: {
-              "test" => "some other upgrade"
+              "repo" => "some other upgrade"
             }
           )
-        updater = described_class.new("test", config: config)
+        updater =
+          described_class.new("repo", config: config, package_name: "test")
         allow(File).to receive(:exist?).and_return(false)
 
         expect(updater.send(:upgrade_command)).to eq(
@@ -65,12 +68,13 @@ describe Deployer::Repo::BaseUpdater do
           instance_double(
             Deployer::Config,
             version: "1.0.1",
-            package_name: "test",
+            package_names: ["test"],
             upgrade_commands: {
               "other" => "some other upgrade"
             }
           )
-        updater = described_class.new("test", config: config)
+        updater =
+          described_class.new("repo", config: config, package_name: "test")
         allow(File).to receive(:exist?).and_return(false)
 
         expect(updater.send(:upgrade_command)).to eq("yarn upgrade test@1.0.1")

--- a/deploy/spec/deployer/repo_spec.rb
+++ b/deploy/spec/deployer/repo_spec.rb
@@ -2,7 +2,7 @@ describe Deployer::Repo do
   let(:config) do
     instance_double(
       Deployer::Config,
-      package_name: "test-pkg",
+      package_names: ["test-pkg"],
       version: "1.2.7"
     )
   end
@@ -10,7 +10,13 @@ describe Deployer::Repo do
   describe "#failure?" do
     it "returns false if the repo update is successful" do
       updater = instance_double(Deployer::Repo::MergeUpdater, run: nil)
-      repo = described_class.new("test", config: config, updater: updater)
+      repo =
+        described_class.new(
+          "test",
+          config: config,
+          updater: updater,
+          package_name: "test-pkg"
+        )
 
       repo.update_package
 
@@ -20,7 +26,13 @@ describe Deployer::Repo do
     it "returns true when updater raises an error" do
       updater = instance_double(Deployer::Repo::MergeUpdater)
       allow(updater).to receive(:run).and_raise(StandardError)
-      repo = described_class.new("test", config: config, updater: updater)
+      repo =
+        described_class.new(
+          "test",
+          config: config,
+          updater: updater,
+          package_name: "test-pkg"
+        )
 
       repo.update_package
 
@@ -31,7 +43,13 @@ describe Deployer::Repo do
   describe "#success?" do
     it "returns true if the repo update is successful" do
       updater = instance_double(Deployer::Repo::MergeUpdater, run: nil)
-      repo = described_class.new("test", config: config, updater: updater)
+      repo =
+        described_class.new(
+          "test",
+          config: config,
+          updater: updater,
+          package_name: "test-pkg"
+        )
 
       repo.update_package
 
@@ -41,7 +59,13 @@ describe Deployer::Repo do
     it "returns false when updater raises an error" do
       updater = instance_double(Deployer::Repo::MergeUpdater)
       allow(updater).to receive(:run).and_raise(StandardError)
-      repo = described_class.new("test", config: config, updater: updater)
+      repo =
+        described_class.new(
+          "test",
+          config: config,
+          updater: updater,
+          package_name: "test-pkg"
+        )
 
       repo.update_package
 
@@ -52,7 +76,13 @@ describe Deployer::Repo do
   describe "#error_message" do
     it "returns nothing when successful" do
       updater = instance_double(Deployer::Repo::MergeUpdater, run: true)
-      repo = described_class.new("test", config: config, updater: updater)
+      repo =
+        described_class.new(
+          "test",
+          config: config,
+          updater: updater,
+          package_name: "test-pkg"
+        )
 
       repo.update_package
 
@@ -61,7 +91,13 @@ describe Deployer::Repo do
 
     it "returns the error message when failed" do
       updater = instance_double(Deployer::Repo::MergeUpdater, run: false)
-      repo = described_class.new("test", config: config, updater: updater)
+      repo =
+        described_class.new(
+          "test",
+          config: config,
+          updater: updater,
+          package_name: "test-pkg"
+        )
       allow(updater).to receive(:run).and_raise(
         Deployer::PushBranchFailure,
         "You don't have permissions to push to this branch"
@@ -78,7 +114,13 @@ describe Deployer::Repo do
   describe "#success_message" do
     it "returns a success message" do
       updater = instance_double(Deployer::Repo::MergeUpdater)
-      repo = described_class.new("test", config: config, updater: updater)
+      repo =
+        described_class.new(
+          "test",
+          config: config,
+          updater: updater,
+          package_name: "test-pkg"
+        )
 
       expect(
         repo.success_message
@@ -89,7 +131,13 @@ describe Deployer::Repo do
   describe "#pr_number" do
     it "returns the PR number" do
       updater = instance_double(Deployer::Repo::MergeUpdater, pr_number: 123)
-      repo = described_class.new("test", config: config, updater: updater)
+      repo =
+        described_class.new(
+          "test",
+          config: config,
+          updater: updater,
+          package_name: "test-pkg"
+        )
 
       expect(repo.pr_number).to eq 123
     end
@@ -102,7 +150,13 @@ describe Deployer::Repo do
           Deployer::Repo::MergeUpdater,
           pr_url: "http://github.com/org/repo/pull/123"
         )
-      repo = described_class.new("test", config: config, updater: updater)
+      repo =
+        described_class.new(
+          "test",
+          config: config,
+          updater: updater,
+          package_name: "test-pkg"
+        )
 
       expect(repo.pr_url).to eq "http://github.com/org/repo/pull/123"
     end

--- a/deploy/spec/deployer_spec.rb
+++ b/deploy/spec/deployer_spec.rb
@@ -92,7 +92,8 @@ describe Deployer do
           Dependabot::NpmAndYarn::UpdateChecker,
           requirements_unlocked_or_can_be?: true,
           can_update?: true,
-          updated_dependencies: [instance_double(Dependabot::Dependency)]
+          updated_dependencies: [instance_double(Dependabot::Dependency)],
+          latest_resolvable_version: "1.0.1"
         )
       )
       stub_find_repos("topbar")
@@ -126,7 +127,7 @@ describe Deployer do
         Deployer::Config.new(
           github_token: "",
           owner: "planningcenter",
-          package_name: "@planningcenter/tapestry-react",
+          package_names: ["@planningcenter/tapestry-react"],
           version: "1.0.1",
           allow_major: true
         )
@@ -153,7 +154,7 @@ describe Deployer do
           Deployer::Config.new(
             github_token: "",
             owner: "planningcenter",
-            package_name: "@planningcenter/tapestry-react",
+            package_names: ["@planningcenter/tapestry-react"],
             version: "1.0.1",
             change_method: "merge",
             branch_name: "staging", # Unique branch name
@@ -173,7 +174,7 @@ describe Deployer do
         Deployer::Config.new(
           github_token: "",
           owner: "planningcenter",
-          package_name: "@planningcenter/tapestry-react",
+          package_names: ["@planningcenter/tapestry-react"],
           version: "1.0.1"
         )
       expect(described_class.new(config).repos.map(&:name)).to eq(%w[test-repo])


### PR DESCRIPTION
The deploy package currently only deploys one package at a time.  We are moving to a world where monorepos can deploy to multiple packages and we need the deploy action to allow for this behavior.

The big change is that deploy depends on package_names instead of package_name.  If you send in package_name, it will set package_names as `[package_name]`.  Other than that, the only other changes are some minor changes to wording to accommodate multiple packages.