### PR TITLE
feat: add lerna qa release workflow

### DIFF
--- a/.github/workflows/lerna-qa-release.yml
+++ b/.github/workflows/lerna-qa-release.yml
@@ -1,0 +1,142 @@
+name: PCO-Release - QA Release Automation
+on:
+  workflow_call:
+    inputs:
+      # Node Specific Inputs
+      install-command:
+        description: "The script command to use to install the package's dependencies"
+        required: false
+        type: string
+        default: "yarn install --check-files"
+      node-version:
+        description: "The version of node to use"
+        required: false
+        type: string
+        default: "20"
+      cache:
+        description: "Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm, or '' for no caching."
+        required: false
+        type: string
+        default: "yarn"
+
+      # Deploy Specific Inputs
+      only:
+        description: "Only run on specific repos. This is a comma separated list of repo names (ie 'people,services,groups')"
+        required: false
+        type: string
+        default: ""
+      include:
+        description: "repos to include without checking. Comma separated list"
+        required: false
+        type: string
+        default: ""
+      exclude:
+        description: "repos to exclude without checking. Comma separated list"
+        required: false
+        type: string
+        default: ""
+      lerna-json-path:
+        description: "path to lerna.json"
+        required: false
+        type: string
+        default: "lerna.json"
+jobs:
+  create-qa-release:
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '@pco-release qa')
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version}}
+          cache: ${{ inputs.cache }}
+      - run: echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> ~/.npmrc
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.PLANNINGCENTER_NPM_TOKEN }}
+      - run: ${{ inputs.install-command }}
+      - run: git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      - run: git config --global user.name "github-actions[bot]"
+      - run: |
+          if git rev-parse --verify origin/pco-release--internal-qa > /dev/null 2>&1; then
+            git checkout pco-release--internal-qa
+          else
+            git checkout -b pco-release--internal-qa
+            git commit --allow-empty -m "New release branch"
+          fi
+      - run: git rebase origin/main --strategy-option=theirs
+      - run: git push -f --set-upstream origin pco-release--internal-qa
+      - run: ./node_modules/.bin/lerna run build
+      - run: ./node_modules/.bin/lerna publish --conventional-prerelease --conventionalCommits --createRelease=github --preid="qa-${{ github.event.issue.number }}" --dist-tag=qa --summary-file -y
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: |
+          echo releases=$(cat ./lerna-publish-summary.json) >> $GITHUB_OUTPUT
+          echo version=$(cat ./lerna-publish-summary.json | jq -r '.[0].version') >> $GITHUB_OUTPUT
+          echo packageNames=$(cat ./lerna-publish-summary.json | jq -r '.[].packageName') >> $GITHUB_OUTPUT
+        id: published_packages
+    outputs:
+      releases: ${{ steps.published_packages.outputs.releases }}
+      version: ${{ steps.published_packages.outputs.version }}
+      packageNames: ${{ steps.published_packages.outputs.packageNames }}
+  deploy-to-proto-for-consumers:
+    needs: create-qa-release
+    runs-on: ubuntu-latest
+    if: ${{ needs.create-qa-release.outputs.releases }}
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Push to protonova branch for Consumers
+        uses: planningcenter/pco-release-action/deploy@v1
+        if: ${{ !contains(github.event.comment.body, '--no-deploy') }}
+        with:
+          app-id: ${{ secrets.PCO_DEPENDENCIES_APP_ID }}
+          private-key: ${{ secrets.PCO_DEPENDENCIES_PRIVATE_KEY }}
+          ref: v${{ needs.create-qa-release.outputs.version }}
+          package-names: ${{ needs.create-qa-release.outputs.packageNames }}
+          change-method: "merge"
+          branch-name: "proto/${{ github.event.repository.name }}-${{ github.event.issue.number }}"
+          only: ${{ inputs.only }}
+          exclude: ${{ inputs.exclude }}
+          include: ${{ inputs.include }}
+          allow-major: true
+          package-json-path: ${{ inputs.lerna-json-path }}
+      - name: Post results to original PR
+        uses: planningcenter/pco-release-action/reporting@v1
+        if: ${{ needs.create-qa-release.outputs.version }}
+        with:
+          pr-number: ${{ github.event.issue.number }}
+          results-json: ${{ env.results_json }}
+          version-tag: v${{ needs.create-qa-release.outputs.version }}
+          actor: ${{ github.actor }}
+          proto-tag: "${{ github.event.repository.name }}-${{ github.event.issue.number }}"
+          release-type: "QA"
+  report-previous-version:
+    needs: create-qa-release
+    if: ${{ !needs.create-qa-release.outputs.releases }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - uses: actions/github-script@v7
+        env:
+          PR_NUMBER: ${{ github.event.issue.number }}
+        with:
+          script: |
+            if (!process.env.PR_NUMBER) return
+            const header = `## No QA release created`
+            const body = "There are no new changes to release, so please use the previous QA version."
+
+            github.rest.issues.createComment({
+              issue_number: process.env.PR_NUMBER,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `${header}\n\n${body}`
+            });


### PR DESCRIPTION
This new action allows you to add a comment `@pco-release qa` on a PR in a lerna repo.  When doing so, it will create a QA release, publish it, and deploy it to protonova.  If you use `@pco-release qa --no-deploy` it will skip the deploy step.

After working, it will report the QA version to the PR that triggered the creation.