### PR TITLE
feat: add lerna-release-on-merge workflow

### DIFF
--- a/.github/workflows/lerna-release-on-merge.yml
+++ b/.github/workflows/lerna-release-on-merge.yml
@@ -1,0 +1,175 @@
+name: PCO-Release - Create Release on Merge
+
+on:
+  workflow_call:
+    inputs:
+      only:
+        description: "Only run on specific repos. This is a comma separated list of repo names (ie 'people,services,groups')"
+        required: false
+        type: string
+        default: ""
+      include:
+        description: "repos to include without checking. Comma separated list"
+        required: false
+        type: string
+        default: ""
+      exclude:
+        description: "repos to exclude without checking. Comma separated list"
+        required: false
+        type: string
+        default: ""
+
+      # Node specific inputs
+      node-version:
+        description: "The version of node to use"
+        required: false
+        type: string
+        default: "20"
+      cache:
+        description: "Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm, or '' for no caching."
+        required: false
+        type: string
+        default: "yarn"
+      install-command:
+        description: "The script command to use to install the package's dependencies"
+        required: false
+        type: string
+        default: "yarn install --check-files"
+
+jobs:
+  create-release:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'pco-release-pending')
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+      - run: git config --global user.email "github-actions[bot]@users.noreply.github.com"
+      - run: git config --global user.name "github-actions[bot]"
+      - run: echo "version=$v$(jq -r .version lerna.json)" >> $GITHUB_ENV
+      - run: git tag -a v${{ env.version }} -m "Release v${{ env.version }}"
+      - run: git push --tags
+      - uses: planningcenter/pco-release-action/create-release-on-merge@v1
+        with:
+          package_json_path: "lerna.json"
+    outputs:
+      release-tag: v${{ env.version }}
+      version: ${{ env.version }}
+  publish:
+    runs-on: ubuntu-latest
+    needs: create-release
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create-release.outputs.release-tag }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.cache }}
+      - run: ${{ inputs.install-command }}
+      - run: ./node_modules/.bin/lerna run build
+      - name: Publish
+        run: |
+          echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> ~/.npmrc
+          ./node_modules/.bin/lerna publish from-package --yes
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.PLANNINGCENTER_NPM_TOKEN }}
+      - name: Publish to Github
+        run: |
+          rm ~/.npmrc
+          echo "//npm.pkg.github.com/:_authToken=$NODE_AUTH_TOKEN" >> ~/.npmrc
+          ./node_modules/.bin/lerna publish from-package --yes --registry=https://npm.pkg.github.com/:_authToken=$NODE_AUTH_TOKEN
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: rm ~/.npmrc
+  deploy:
+    runs-on: ubuntu-latest
+    needs: [publish, create-release]
+    permissions:
+      contents: write
+      pull-requests: write
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ needs.create-release.outputs.release-tag }}
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ inputs.node-version }}
+          cache: ${{ inputs.cache }}
+      - run: ${{ inputs.install-command }}
+      - id: packages
+        run: |
+          packages=$(./node_modules/.bin/lerna list --json | jq -c '.')
+          echo "packages=$packages" >> $GITHUB_OUTPUT
+      - uses: actions/github-script@v7
+        id: find-package-names
+        with:
+          script: |
+            const packages = JSON.parse(process.env.PACKAGES)
+            const version = process.env.VERSION
+            const packageNames = packages.filter((pkg) => pkg.version === version).map(pkg => pkg.name).join(',')
+            core.setOutput('package-names', packageNames)
+        env:
+          PACKAGES: ${{ steps.packages.outputs.packages }}
+          VERSION: ${{ needs.create-release.outputs.version }}
+      - name: Push to Consumers
+        id: push-to-consumers
+        uses: planningcenter/pco-release-action/deploy@v1
+        with:
+          app-id: ${{ secrets.PCO_DEPENDENCIES_APP_ID }}
+          private-key: ${{ secrets.PCO_DEPENDENCIES_PRIVATE_KEY }}
+          ref: ${{ needs.create-release.outputs.release-tag }}
+          change-method: "pr"
+          only: ${{ inputs.only }}
+          allow-major: false
+          include: ${{ inputs.include }}
+          exclude: ${{ inputs.exclude }}
+          package-json-path: "lerna.json"
+          package-names: ${{ steps.find-package-names.outputs.package-names }}
+      - name: Post results to original PR
+        uses: actions/github-script@v7
+        env:
+          ACTOR: ${{ github.actor }}
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const results = JSON.parse(process.env.results_json);
+            const body = `## Release Automation Results
+
+            Triggered by: @${process.env.ACTOR}
+
+            ${results.successful_repos.length > 0 ? "### PRs created" : ""}
+
+            ${results.successful_repos.map(repo => "- [" + repo.name + "](" + repo.pr_url + ")").join("\n")}
+
+            ${results.failed_repos.length > 0 ? "### PRs failed" : ""}
+
+            ${results.failed_repos.map(repo => "- " + repo.name + ": " + repo.message).join("\n")}
+
+            ### Next steps
+
+            Run the following command to approve all the PRs:
+
+            \`\`\`
+              ${results.successful_repos.map(repo => "gh pr review " + repo.pr_number + " --repo=planningcenter/" + repo.name + " -a").join("\n")}
+            \`\`\`
+
+            ### If you need to revert
+
+            - Go to the actions tab
+            - Click \`Revert\` on the left hand actions list
+            - Click to the \`Run workflow\` button on the right
+            - enter the last successful version and click \`Run workflow\`
+            `
+            github.rest.issues.createComment({
+              issue_number: process.env.PR_NUMBER,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: body
+            });
+
+            if (results.failed_repos.length > 0) {
+              throw new Error("Some PRs failed to create");
+            }


### PR DESCRIPTION
When a PR is merged in a lerna monorepo, this action will:

- create a release
- publish the release to github and npm
- create PRs in all consuming apps to upgrade to the latest version
- report the results back to the release PR