### PR TITLE
fix(deploy): properly detect when pkg names is ""

### DIFF
--- a/deploy/run.rb
+++ b/deploy/run.rb
@@ -21,7 +21,7 @@ def run_for_packages
 end
 
 def package_names
-  return ENV["PACKAGE_NAMES"].split(",") if ENV["PACKAGE_NAMES"]
+  return ENV["PACKAGE_NAMES"].split(",") unless ENV["PACKAGE_NAMES"]&.empty?
 
   [ENV["PACKAGE_NAME"]]
 end


### PR DESCRIPTION
empty strings evaluate to true, so this was falsely using empty strings for package names

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209131249629386