### PR TITLE
feat: add reactions to comment commands

### DIFF
--- a/.github/workflows/lerna-deploy-rc.yml
+++ b/.github/workflows/lerna-deploy-rc.yml
@@ -3,43 +3,52 @@ on:
   workflow_call:
     inputs:
       node-version:
-        description: "The version of node to use"
+        description: 'The version of node to use'
         required: false
         type: string
-        default: "20"
+        default: '20'
       cache:
         description: "Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm, or '' for no caching."
         required: false
         type: string
-        default: "yarn"
+        default: 'yarn'
       install-command:
         description: "The script command to use to install the package's dependencies"
         required: false
         type: string
-        default: "yarn install --check-files"
+        default: 'yarn install --check-files'
 
       # Deploy Specific Inputs
       only:
         description: "Only run on specific repos. This is a comma separated list of repo names (ie 'people,services,groups')"
         required: false
         type: string
-        default: ""
+        default: ''
       include:
-        description: "repos to include without checking. Comma separated list"
+        description: 'repos to include without checking. Comma separated list'
         required: false
         type: string
-        default: ""
+        default: ''
       exclude:
-        description: "repos to exclude without checking. Comma separated list"
+        description: 'repos to exclude without checking. Comma separated list'
         required: false
         type: string
-        default: ""
+        default: ''
       upgrade-commands:
-        description: "JSON string of repo names and their specific upgrade commands. Useful for monorepos where the package.json does not exist in the root directory."
+        description: 'JSON string of repo names and their specific upgrade commands. Useful for monorepos where the package.json does not exist in the root directory.'
         required: false
         type: string
-        default: "{}"
+        default: '{}'
 jobs:
+  react-to-comment:
+    if: github.event.issue.pull_request && startsWith(github.event.comment.body, '@pco-release deploy')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add reactions
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{github.event.comment.id}}
+          reactions: '+1'
   deploy-to-staging-for-consumers:
     if: github.event.issue.pull_request && startsWith(github.event.comment.body, '@pco-release deploy')
     runs-on: ubuntu-latest
@@ -78,8 +87,8 @@ jobs:
           app-id: ${{ secrets.PCO_DEPENDENCIES_APP_ID }}
           private-key: ${{ secrets.PCO_DEPENDENCIES_PRIVATE_KEY }}
           ref: v${{ steps.find-version.outputs.version }}
-          change-method: "merge"
-          branch-name: "staging"
+          change-method: 'merge'
+          branch-name: 'staging'
           only: ${{ inputs.only }}
           exclude: ${{ inputs.exclude }}
           include: ${{ inputs.include }}
@@ -95,4 +104,4 @@ jobs:
           results-json: ${{ env.results_json }}
           version-tag: ${{ steps.find-version.outputs.version }}
           actor: ${{ github.actor }}
-          release-type: "RC"
+          release-type: 'RC'

--- a/.github/workflows/lerna-qa-release.yml
+++ b/.github/workflows/lerna-qa-release.yml
@@ -7,40 +7,49 @@ on:
         description: "The script command to use to install the package's dependencies"
         required: false
         type: string
-        default: "yarn install --check-files"
+        default: 'yarn install --check-files'
       node-version:
-        description: "The version of node to use"
+        description: 'The version of node to use'
         required: false
         type: string
-        default: "20"
+        default: '20'
       cache:
         description: "Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm, or '' for no caching."
         required: false
         type: string
-        default: "yarn"
+        default: 'yarn'
 
       # Deploy Specific Inputs
       only:
         description: "Only run on specific repos. This is a comma separated list of repo names (ie 'people,services,groups')"
         required: false
         type: string
-        default: ""
+        default: ''
       include:
-        description: "repos to include without checking. Comma separated list"
+        description: 'repos to include without checking. Comma separated list'
         required: false
         type: string
-        default: ""
+        default: ''
       exclude:
-        description: "repos to exclude without checking. Comma separated list"
+        description: 'repos to exclude without checking. Comma separated list'
         required: false
         type: string
-        default: ""
+        default: ''
       lerna-json-path:
-        description: "path to lerna.json"
+        description: 'path to lerna.json'
         required: false
         type: string
-        default: "lerna.json"
+        default: 'lerna.json'
 jobs:
+  react-to-comment:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '@pco-release qa')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add reactions
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{github.event.comment.id}}
+          reactions: '+1'
   create-qa-release:
     if: github.event.issue.pull_request && startsWith(github.event.comment.body, '@pco-release qa')
     runs-on: ubuntu-latest
@@ -100,8 +109,8 @@ jobs:
           private-key: ${{ secrets.PCO_DEPENDENCIES_PRIVATE_KEY }}
           ref: v${{ needs.create-qa-release.outputs.version }}
           package-names: ${{ needs.create-qa-release.outputs.packageNames }}
-          change-method: "merge"
-          branch-name: "proto/${{ github.event.repository.name }}-${{ github.event.issue.number }}"
+          change-method: 'merge'
+          branch-name: 'proto/${{ github.event.repository.name }}-${{ github.event.issue.number }}'
           only: ${{ inputs.only }}
           exclude: ${{ inputs.exclude }}
           include: ${{ inputs.include }}
@@ -115,8 +124,8 @@ jobs:
           results-json: ${{ env.results_json }}
           version-tag: v${{ needs.create-qa-release.outputs.version }}
           actor: ${{ github.actor }}
-          proto-tag: "${{ github.event.repository.name }}-${{ github.event.issue.number }}"
-          release-type: "QA"
+          proto-tag: '${{ github.event.repository.name }}-${{ github.event.issue.number }}'
+          release-type: 'QA'
   report-previous-version:
     needs: create-qa-release
     if: ${{ !needs.create-qa-release.outputs.releases }}

--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -6,63 +6,72 @@ on:
         description: "The script command to use to install the package's dependencies"
         required: false
         type: string
-        default: "yarn install --check-files"
+        default: 'yarn install --check-files'
       build-command:
-        description: "The script command to use to build the package"
+        description: 'The script command to use to build the package'
         required: false
         type: string
-        default: "yarn build"
+        default: 'yarn build'
       test-command:
-        description: "The script command to use to test the package"
+        description: 'The script command to use to test the package'
         required: false
         type: string
-        default: "yarn test"
+        default: 'yarn test'
       prepublish-command:
-        description: "The command to run to publish a prerelease version of the package to NPM"
+        description: 'The command to run to publish a prerelease version of the package to NPM'
         required: false
         type: string
-        default: "npm publish --tag next"
+        default: 'npm publish --tag next'
       cache:
         description: "Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm, or '' for no caching."
         required: false
         type: string
-        default: "yarn"
+        default: 'yarn'
       build-directory:
-        description: "The build output directory"
+        description: 'The build output directory'
         required: false
         type: string
-        default: "dist"
+        default: 'dist'
       only:
         description: "Only run on specific repos. This is a comma separated list of repo names (ie 'people,services,groups')"
         required: false
         type: string
-        default: ""
+        default: ''
       include:
-        description: "repos to include without checking. Comma separated list"
+        description: 'repos to include without checking. Comma separated list'
         required: false
         type: string
-        default: ""
+        default: ''
       exclude:
-        description: "repos to exclude without checking. Comma separated list"
+        description: 'repos to exclude without checking. Comma separated list'
         required: false
         type: string
-        default: ""
+        default: ''
       upgrade-commands:
-        description: "JSON string of repo names and their specific upgrade commands. Useful for monorepos where the package.json does not exist in the root directory."
+        description: 'JSON string of repo names and their specific upgrade commands. Useful for monorepos where the package.json does not exist in the root directory.'
         required: false
         type: string
-        default: "{}"
+        default: '{}'
       package-json-path:
-        description: "path to package.json"
+        description: 'path to package.json'
         required: false
         type: string
-        default: "package.json"
+        default: 'package.json'
       yarn-version-command:
-        description: "command to run to update version"
+        description: 'command to run to update version'
         required: false
         type: string
-        default: "yarn version"
+        default: 'yarn version'
 jobs:
+  react-to-comment:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '@pco-release qa')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add reactions
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{github.event.comment.id}}
+          reactions: '+1'
   create-qa-release:
     if: github.event.issue.pull_request && contains(github.event.comment.body, '@pco-release qa')
     runs-on: ubuntu-latest
@@ -106,8 +115,8 @@ jobs:
           app-id: ${{ secrets.PCO_DEPENDENCIES_APP_ID }}
           private-key: ${{ secrets.PCO_DEPENDENCIES_PRIVATE_KEY }}
           ref: ${{ needs.create-qa-release.outputs.release-tag }}
-          change-method: "merge"
-          branch-name: "proto/${{ github.event.repository.name }}-${{ github.event.issue.number }}"
+          change-method: 'merge'
+          branch-name: 'proto/${{ github.event.repository.name }}-${{ github.event.issue.number }}'
           only: ${{ inputs.only }}
           exclude: ${{ inputs.exclude }}
           include: ${{ inputs.include }}
@@ -121,5 +130,5 @@ jobs:
           results-json: ${{ env.results_json }}
           version-tag: ${{ needs.create-qa-release.outputs.release-tag }}
           actor: ${{ github.actor }}
-          proto-tag: "${{ github.event.repository.name }}-${{ github.event.issue.number }}"
-          release-type: "QA"
+          proto-tag: '${{ github.event.repository.name }}-${{ github.event.issue.number }}'
+          release-type: 'QA'

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -6,63 +6,72 @@ on:
         description: "The script command to use to install the package's dependencies"
         required: false
         type: string
-        default: "yarn install --check-files"
+        default: 'yarn install --check-files'
       build-command:
-        description: "The script command to use to build the package"
+        description: 'The script command to use to build the package'
         required: false
         type: string
-        default: "yarn build"
+        default: 'yarn build'
       test-command:
-        description: "The script command to use to test the package"
+        description: 'The script command to use to test the package'
         required: false
         type: string
-        default: "yarn test"
+        default: 'yarn test'
       prepublish-command:
-        description: "The command to run to publish a prerelease version of the package to NPM"
+        description: 'The command to run to publish a prerelease version of the package to NPM'
         required: false
         type: string
-        default: "npm publish --tag next"
+        default: 'npm publish --tag next'
       cache:
         description: "Used to specify a package manager for caching in the default directory. Supported values: npm, yarn, pnpm, or '' for no caching."
         required: false
         type: string
-        default: "yarn"
+        default: 'yarn'
       build-directory:
-        description: "The build output directory"
+        description: 'The build output directory'
         required: false
         type: string
-        default: "dist"
+        default: 'dist'
       only:
         description: "Only run on specific repos. This is a comma separated list of repo names (ie 'people,services,groups')"
         required: false
         type: string
-        default: ""
+        default: ''
       include:
-        description: "repos to include without checking. Comma separated list"
+        description: 'repos to include without checking. Comma separated list'
         required: false
         type: string
-        default: ""
+        default: ''
       exclude:
-        description: "repos to exclude without checking. Comma separated list"
+        description: 'repos to exclude without checking. Comma separated list'
         required: false
         type: string
-        default: ""
+        default: ''
       upgrade-commands:
-        description: "JSON string of repo names and their specific upgrade commands. Useful for monorepos where the package.json does not exist in the root directory."
+        description: 'JSON string of repo names and their specific upgrade commands. Useful for monorepos where the package.json does not exist in the root directory.'
         required: false
         type: string
-        default: "{}"
+        default: '{}'
       package-json-path:
-        description: "path to package.json"
+        description: 'path to package.json'
         required: false
         type: string
-        default: "package.json"
+        default: 'package.json'
       yarn-version-command:
-        description: "command to run to update version"
+        description: 'command to run to update version'
         required: false
         type: string
-        default: "yarn version"
+        default: 'yarn version'
 jobs:
+  react-to-comment:
+    if: github.event.issue.pull_request && contains(github.event.comment.body, '@pco-release rc')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add reactions
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          comment-id: ${{github.event.comment.id}}
+          reactions: '+1'
   create-rc-release:
     if: github.event.issue.pull_request && contains(github.event.comment.body, '@pco-release rc')
     runs-on: ubuntu-latest
@@ -106,8 +115,8 @@ jobs:
           app-id: ${{ secrets.PCO_DEPENDENCIES_APP_ID }}
           private-key: ${{ secrets.PCO_DEPENDENCIES_PRIVATE_KEY }}
           ref: ${{ needs.create-rc-release.outputs.release-tag }}
-          change-method: "merge"
-          branch-name: "staging"
+          change-method: 'merge'
+          branch-name: 'staging'
           only: ${{ inputs.only }}
           exclude: ${{ inputs.exclude }}
           include: ${{ inputs.include }}
@@ -121,4 +130,4 @@ jobs:
           results-json: ${{ env.results_json }}
           version-tag: ${{ needs.create-rc-release.outputs.release-tag }}
           actor: ${{ github.actor }}
-          release-type: "RC"
+          release-type: 'RC'


### PR DESCRIPTION
When a person adds a command like `@pco-release rc`, it can be unclear if anything is happening.  This adds a small feature to add a thumbs up reaction to all commands that trigger.

Closes Issue #42

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209161257295731