### PR TITLE
fix(reporting): add proto_tag to env variables

### DIFF
--- a/reporting/action.yml
+++ b/reporting/action.yml
@@ -28,6 +28,7 @@ runs:
         ACTOR: ${{ inputs.actor }}
         VERSION_TAG: ${{ inputs.version-tag }}
         RELEASE_TYPE: ${{ inputs.release-type }}
+        PROTO_TAG: ${{ inputs.proto-tag }}
       with:
         script: |
           function getBody() {


### PR DESCRIPTION
Protonova links were not being logged because the environment variable wasn't set up correctly.  This fixes that and ensures that the proto environment is logged to the PR comment.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209206999143815