### PR TITLE
fix(lerna-qa): Fix building QA build

### DIFF
--- a/.github/workflows/lerna-qa-release.yml
+++ b/.github/workflows/lerna-qa-release.yml
@@ -73,8 +73,8 @@ jobs:
           result-encoding: string
       - uses: actions/checkout@v4
         with:
-          ref: main
-          fetch-depth: 0
+          ref: ${{ steps.get-pr-ref.outputs.result }}
+          fetch-tags: true
       - uses: actions/setup-node@v4
         with:
           node-version: ${{ inputs.node-version}}

--- a/.github/workflows/lerna-qa-release.yml
+++ b/.github/workflows/lerna-qa-release.yml
@@ -114,20 +114,20 @@ jobs:
           jq --arg new_version "$new_version" '.version = $new_version' lerna.json > lerna.tmp.json && mv lerna.tmp.json lerna.json
           git add lerna.json
           git commit -m "QA Release"
-      - run: |
-          if git rev-parse --verify origin/pco-release--internal-qa > /dev/null 2>&1; then
-            git checkout pco-release--internal-qa
-          else
-            git checkout -b pco-release--internal-qa
-            git commit --allow-empty -m "New release branch"
-          fi
-      - run: git rebase origin/main --strategy-option=theirs
-      - run: git push -f --set-upstream origin pco-release--internal-qa
-      - run: ./node_modules/.bin/lerna run build
-      - run: ./node_modules/.bin/lerna publish --conventional-prerelease --conventionalCommits --createRelease=github --preid="qa-${{ github.event.issue.number }}" --dist-tag=qa --summary-file -y
+      - name: Run lerna build
+        if: steps.check-if-should-run.outputs.should_run == 'true'
+        run: ./node_modules/.bin/lerna run build
+      - if: steps.check-if-should-run.outputs.should_run == 'true'
+        name: Run lerna publish
+        run: |
+          possible_amend_command=$(if [ "${{ steps.check-if-should-run.outputs.amend_commit }}" == "true" ]; then echo "--amend"; fi)
+          ./node_modules/.bin/lerna publish --conventional-prerelease --conventionalCommits --createRelease=github --preid="qa-${{ github.event.issue.number }}" --dist-tag=qa --summary-file -y --no-push $possible_amend_command
+          git push origin --tags
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: |
+      - name: Set results to output
+        if: steps.check-if-should-run.outputs.should_run == 'true'
+        run: |
           echo releases=$(cat ./lerna-publish-summary.json) >> $GITHUB_OUTPUT
           echo version=$(cat ./lerna-publish-summary.json | jq -r '.[0].version') >> $GITHUB_OUTPUT
           echo packageNames=$(cat ./lerna-publish-summary.json | jq -r '.[].packageName') >> $GITHUB_OUTPUT

--- a/.github/workflows/lerna-qa-release.yml
+++ b/.github/workflows/lerna-qa-release.yml
@@ -107,6 +107,13 @@ jobs:
           else
             echo "should_run=false" >> $GITHUB_OUTPUT
           fi
+      - if: steps.check-if-should-run.outputs.should_run == 'true'
+        name: Update lerna.json version for next release
+        run: |
+          new_version="${{ steps.get-last-qa-version.outputs.last_version }}"
+          jq --arg new_version "$new_version" '.version = $new_version' lerna.json > lerna.tmp.json && mv lerna.tmp.json lerna.json
+          git add lerna.json
+          git commit -m "QA Release"
       - run: |
           if git rev-parse --verify origin/pco-release--internal-qa > /dev/null 2>&1; then
             git checkout pco-release--internal-qa

--- a/.github/workflows/lerna-qa-release.yml
+++ b/.github/workflows/lerna-qa-release.yml
@@ -85,6 +85,28 @@ jobs:
       - run: ${{ inputs.install-command }}
       - run: git config --global user.email "github-actions[bot]@users.noreply.github.com"
       - run: git config --global user.name "github-actions[bot]"
+      - name: Get last QA version
+        id: get-last-qa-version
+        run: |
+          git fetch --tags
+          LAST_VERSION=$(git tag -l "*-qa-${{ github.event.issue.number }}*" --sort=-v:refname | head -n 1)
+          echo "last_version=$LAST_VERSION" >> $GITHUB_OUTPUT
+      - name: Run checks to see if we should run
+        if: steps.get-last-qa-version.outputs.last_version
+        id: check-if-should-run
+        run: |
+          if [ -z "${{ steps.get-last-qa-version.outputs.last_version }}" ]; then
+            echo "should_run=true" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          LAST_VERSION_SHA=$(git rev-list -n 1 --skip=1 ${{ steps.get-last-qa-version.outputs.last_version }})
+          CURRENT_SHA=$(git rev-parse HEAD)
+          if [ "$LAST_VERSION_SHA" != "$CURRENT_SHA" ]; then
+            echo "amend_commit=true" >> $GITHUB_OUTPUT
+            echo "should_run=true" >> $GITHUB_OUTPUT
+          else
+            echo "should_run=false" >> $GITHUB_OUTPUT
+          fi
       - run: |
           if git rev-parse --verify origin/pco-release--internal-qa > /dev/null 2>&1; then
             git checkout pco-release--internal-qa

--- a/.github/workflows/lerna-qa-release.yml
+++ b/.github/workflows/lerna-qa-release.yml
@@ -57,6 +57,20 @@ jobs:
       contents: write
       pull-requests: write
     steps:
+      - name: Get PR head ref
+        id: get-pr-ref
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const issueUrl = context.payload.issue.pull_request.url;
+            const prNumber = issueUrl.split('/').pop();
+            const pr = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber,
+            });
+            return pr.data.head.ref;
+          result-encoding: string
       - uses: actions/checkout@v4
         with:
           ref: main


### PR DESCRIPTION
Prior to this PR, the QA building process for lerna was broken.  The first problem was that it was using the `main` branch to make the builds.  This PR changes that so that the branch of each PR is used.

In order to make that work, more logic was needed to detect specific things about how to build correctly:

- It needs to detect the previous QA version for this PR.  We want to increment (or not build if there are no changes) for each QA  build for this PR.
- It needs to create a better system for detecting changes.  Lerna creates a commit for the version publish, so we need to be able to compare the second to last commit to the current commit of the PR so that we can determine if a new QA build is necessary.

With this done, the QA command will now efficiently create new QA builds in an incremental fashion.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1209206999143817