### PR TITLE
fix: setup runner in dependabot proxy

### DIFF
--- a/deploy/lib/deployer/repo/dependabot_proxy.rb
+++ b/deploy/lib/deployer/repo/dependabot_proxy.rb
@@ -5,6 +5,19 @@ class Deployer
         @config = config
         @name = name
         @package_name = package_name
+        self.class.setup(config)
+      end
+
+      def self.setup(config)
+        return if @setup_run
+
+        Dir.chdir(Dependabot::NpmAndYarn::NativeHelpers.native_helpers_root) do
+          CommandLine.new(config).execute(
+            "npm install --silent",
+            error_class: AutoMergeFailure
+          )
+        end
+        @setup_run = true
       end
 
       def source

--- a/deploy/lib/deployer/repo/dependabot_pull_request_updater.rb
+++ b/deploy/lib/deployer/repo/dependabot_pull_request_updater.rb
@@ -4,7 +4,6 @@ class Deployer
   class Repo
     class DependabotPullRequestUpdater < PullRequestUpdater
       def run
-        setup_runner
         verify_upgrade_satisfies
         create_pr
         automerge_pr if config.automerge
@@ -34,15 +33,6 @@ class Deployer
 
       def checker
         dependabot_proxy.checker
-      end
-
-      def setup_runner
-        Dir.chdir(Dependabot::NpmAndYarn::NativeHelpers.native_helpers_root) do
-          CommandLine.new(config).execute(
-            "npm install --silent",
-            error_class: AutoMergeFailure
-          )
-        end
       end
 
       def create_pr


### PR DESCRIPTION
With the detection whether dependencies exist moving earlier in the process, we were missing the setup of the repo to properly detect if the dependency exists.  Dependabot depends on an environment where npm modules can be referenced and it needs to run `npm install` before running the comparison.

This hoists that behavior to run before any checks are run.  It also detects if it has already been run so that the run isn't repeated unnecessarily.