### PR TITLE
fix: don't skip should_run check if no last version

### DIFF
--- a/.github/workflows/lerna-qa-release.yml
+++ b/.github/workflows/lerna-qa-release.yml
@@ -92,7 +92,6 @@ jobs:
           LAST_VERSION=$(git tag -l "*-qa-${{ github.event.issue.number }}*" --sort=-v:refname | head -n 1)
           echo "last_version=$LAST_VERSION" >> $GITHUB_OUTPUT
       - name: Run checks to see if we should run
-        if: steps.get-last-qa-version.outputs.last_version
         id: check-if-should-run
         run: |
           if [ -z "${{ steps.get-last-qa-version.outputs.last_version }}" ]; then


### PR DESCRIPTION
we should always run if we don't have a last version