### PR TITLE
fix: Don't fail when checking non-compliant repos

### DIFF
--- a/deploy/lib/deployer/repo.rb
+++ b/deploy/lib/deployer/repo.rb
@@ -20,6 +20,7 @@ class Deployer
       return false if config.only.any? && !config.only.include?(name)
       return false if config.exclude.include?(name)
 
+      config.log("Checking if dependency exists #{name} (#{package_name})")
       !dependabot_proxy.dependency.nil?
     end
 

--- a/deploy/lib/deployer/repo/dependabot_proxy.rb
+++ b/deploy/lib/deployer/repo/dependabot_proxy.rb
@@ -58,6 +58,8 @@ class Deployer
             .parse
             .select(&:top_level?)
             .find { |dep| dep.name == package_name }
+      rescue Dependabot::DependencyFileNotFound, Dependabot::BranchNotFound
+        nil
       end
 
       def checker


### PR DESCRIPTION
During the process of checking if a repo has a dependency on the library we're updating, it can check many different types of repos.  Some of those don't have `main` branches or they don't have `package.json` files.   In those cases, we will just rescue from those situations and just say that there are no dependencies.

In addition, I added some logging to give a bit more clarity into when things might be failing.