### PR TITLE
feature(lerna): allow upgrade commands to be passed to deploy

### DIFF
--- a/.github/workflows/lerna-qa-release.yml
+++ b/.github/workflows/lerna-qa-release.yml
@@ -40,6 +40,11 @@ on:
         required: false
         type: string
         default: 'lerna.json'
+      upgrade-commands:
+        description: 'JSON string of repo names and their specific upgrade commands. Useful for monorepos where the package.json does not exist in the root directory.'
+        required: false
+        type: string
+        default: '{}'
 jobs:
   react-to-comment:
     if: github.event.issue.pull_request && contains(github.event.comment.body, '@pco-release qa')
@@ -162,6 +167,7 @@ jobs:
           only: ${{ inputs.only }}
           exclude: ${{ inputs.exclude }}
           include: ${{ inputs.include }}
+          upgrade-commands: ${{ inputs.upgrade-commands }}
           allow-major: true
           package-json-path: ${{ inputs.lerna-json-path }}
       - name: Post results to original PR

--- a/.github/workflows/lerna-release-on-merge.yml
+++ b/.github/workflows/lerna-release-on-merge.yml
@@ -35,6 +35,11 @@ on:
         required: false
         type: string
         default: "yarn install --check-files"
+      upgrade-commands:
+        description: "JSON string of repo names and their specific upgrade commands. Useful for monorepos where the package.json does not exist in the root directory."
+        required: false
+        type: string
+        default: "{}"
 
 jobs:
   create-release:
@@ -131,6 +136,7 @@ jobs:
           allow-major: false
           include: ${{ inputs.include }}
           exclude: ${{ inputs.exclude }}
+          upgrade-commands: ${{ inputs.upgrade-commands }}
           package-json-path: "lerna.json"
           package-names: ${{ steps.find-package-names.outputs.package-names }}
       - name: Post results to original PR


### PR DESCRIPTION
# Allow bespoke upgrade commands

@planningcenter/chat-react-native is failing to deploy to CCA. We need to be able to use npm instead of yarn for the targets we support that do not use yarn. Since these are general actions, I'm adding this for all of the lerna actions that we use that call deploy.
