### PR TITLE
fix: do not auto-deploy major RCs

### DIFF
--- a/.github/workflows/lerna-deploy-rc.yml
+++ b/.github/workflows/lerna-deploy-rc.yml
@@ -98,7 +98,7 @@ jobs:
           exclude: ${{ inputs.exclude }}
           include: ${{ inputs.include }}
           upgrade-commands: ${{ inputs.upgrade-commands }}
-          allow-major: true
+          allow-major: false
           version: ${{ steps.find-version.outputs.version }}
           package-json-path: lerna.json
           package-names: ${{ steps.find-package-names.outputs.package-names }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -121,7 +121,7 @@ jobs:
           exclude: ${{ inputs.exclude }}
           include: ${{ inputs.include }}
           upgrade-commands: ${{ inputs.upgrade-commands }}
-          allow-major: true
+          allow-major: false
           package-json-path: ${{ inputs.package-json-path }}
       - name: Post results to original PR
         uses: planningcenter/pco-release-action/reporting@v1


### PR DESCRIPTION
Because major versions contain breaking changes, there is a high probability that deploying RCs will break staging environments. Because of that, let's remove the deploy ability for release candidates for major updates.

This change does not apply to qa builds, which push to protonova environments.  Those can still be useful for creating an environment to explore the impacts of a major change on an isolated environment.