### PR TITLE
fix(deploy): ensure package manager check doesn't leak

### DIFF
--- a/deploy/action.yml
+++ b/deploy/action.yml
@@ -79,7 +79,7 @@ runs:
     - name: Setup Node
       uses: actions/setup-node@v4
       with:
-        node-version: "18"
+        node-version: '20'
     - name: Enable Corepack
       shell: bash
       run: export COREPACK_ENABLE_DOWNLOAD_PROMPT=0 && corepack enable

--- a/deploy/lib/deployer/repo/dependabot_proxy.rb
+++ b/deploy/lib/deployer/repo/dependabot_proxy.rb
@@ -101,13 +101,23 @@ class Deployer
 
       def npm_and_yarn_fetcher
         @npm_and_yarn_fetcher ||= begin
-          fetcher = Dependabot::FileFetchers.for_package_manager("npm_and_yarn").new(
-            source: source,
-            credentials: credentials
-          )
-          sanitize_yarnrc_yml(fetcher)
-          fetcher
+          in_temp_dir do
+            fetcher = Dependabot::FileFetchers.for_package_manager("npm_and_yarn").new(
+              source: source,
+              credentials: credentials
+              )
+              sanitize_yarnrc_yml(fetcher)
+              fetcher
+          end
         end
+      end
+
+      def in_temp_dir(&block)
+        dir = File.join(Dir.tmpdir, "dependabot_#{name}")
+        FileUtils.mkdir_p(dir) unless Dir.exist?(dir)
+        Dir.chdir(dir, &block)
+      ensure
+        FileUtils.rm_rf(dir) if Dir.exist?(dir)
       end
 
       def sanitize_yarnrc_yml(fetcher)


### PR DESCRIPTION
With the upgrade of dependabot recently, it created a scenario where calling corepack actions (which are now standard in the newer versions of dependabot) were looking in the incorrect place, since corepack will look at parent directories if the current one does not satisfy.

This issue was causing the package.json in the root of *this* repo to update to set the package manager to the one used in one of the repos we were copying.

### Solution

To fix the solution, we are ensuring that we are cloning the dependency files into temporary directories.

### Testing

I tested this locally as well as in [the testing repo](https://github.com/planningcenter/test-js-auto-deploy-pkg/actions/runs/15886890798).  In the testing, I found that there were some conflicts with using node 18, so I upgraded to 20.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210642109574397