### PR TITLE
feat(Deploy): Improve messaging for skipped updates

### DIFF
--- a/deploy/lib/deployer/repo.rb
+++ b/deploy/lib/deployer/repo.rb
@@ -15,6 +15,12 @@ class Deployer
       return skipped! unless attempt_to_update?
       updater.run
 
+      if updater.skipped
+        self.status = :skipped
+        @repo_upgrade_status = :version_bump_not_possible
+        return
+      end
+
       self.status = :success
       self.success = true
     rescue StandardError => e
@@ -86,6 +92,8 @@ class Deployer
         "Skipped #{name} because repo manages non-urgent updates"
       when :excluded_no_dependency
         "Skipped #{name} because it does not have the dependency"
+      when :version_bump_not_possible
+        "Skipped #{name} because the version bump is not possible (usually because of a major version bump)"
       end
     end
 

--- a/deploy/lib/deployer/repo.rb
+++ b/deploy/lib/deployer/repo.rb
@@ -1,20 +1,26 @@
+require 'byebug'
 class Deployer
   class Repo
-    def initialize(name, package_name:, config:, updater: nil, config_file: ConfigFile.new(name, config: config))
+    def initialize(name, package_name:, config:, updater: nil, config_file: ConfigFile.new(name, config: config), dependabot_proxy: Deployer::Repo::DependabotProxy.new(name, config: config, package_name: package_name))
       @name = name
       @config = config
       @package_name = package_name
       @updater = updater || default_updater
       @config_file = config_file
+      @status = :pending
+      @dependabot_proxy = dependabot_proxy
     end
 
     def update_package
+      return skipped! unless attempt_to_update?
       updater.run
 
+      self.status = :success
       self.success = true
     rescue StandardError => e
       self.error_message = e.message
       self.success = false
+      self.status = :failure
     end
 
     def exclude_from_reporting?
@@ -22,7 +28,7 @@ class Deployer
     end
 
     def attempt_to_update?
-      repo_upgrade_status == :attempt_to_upgrade
+      repo_upgrade_status == :attempt_to_update
     end
 
     def success_message
@@ -38,28 +44,50 @@ class Deployer
     end
 
     def success?
-      success
+      status == :success
     end
 
     def failure?
-      !success?
+      status == :failure
     end
 
     def skipped?
-      false
+      status == :skipped
     end
 
-    def dependabot_proxy
-      @dependabot_proxy ||= Deployer::Repo::DependabotProxy.new(name, config: config, package_name: package_name)
+    def message
+      case status
+      when :skipped
+        skipped_message
+      when :success
+        success_message
+      when :failure
+        error_message
+      end
     end
 
-    attr_reader :name, :error_message, :package_name
+    attr_reader :name, :error_message, :package_name, :dependabot_proxy
 
     private
 
     attr_reader :config, :updater, :config_file
-    attr_accessor :success
+    attr_accessor :success, :status
     attr_writer :error_message
+
+    def skipped!
+      self.status = :skipped
+    end
+
+    def skipped_message
+      case repo_upgrade_status
+      when :excluded_explicitly
+        "Skipped #{name} because it is excluded from reporting"
+      when :excluded_by_pr_level
+        "Skipped #{name} because repo manages non-urgent updates"
+      when :excluded_no_dependency
+        "Skipped #{name} because it does not have the dependency"
+      end
+    end
 
     def repo_upgrade_status
       @repo_upgrade_status ||= begin
@@ -70,7 +98,7 @@ class Deployer
         config.log("Checking if dependency exists #{name} (#{package_name})")
         return :excluded_no_dependency if dependabot_proxy.dependency.nil?
 
-        :attempt_to_upgrade
+        :attempt_to_update
       end
     end
 

--- a/deploy/lib/deployer/repo.rb
+++ b/deploy/lib/deployer/repo.rb
@@ -45,6 +45,10 @@ class Deployer
       !success?
     end
 
+    def skipped?
+      false
+    end
+
     def dependabot_proxy
       @dependabot_proxy ||= Deployer::Repo::DependabotProxy.new(name, config: config, package_name: package_name)
     end

--- a/deploy/lib/deployer/repo/base_updater.rb
+++ b/deploy/lib/deployer/repo/base_updater.rb
@@ -28,6 +28,10 @@ class Deployer
         "https://github.com/#{owner}/#{name}/pull/#{pr_number}"
       end
 
+      def skipped
+        false
+      end
+
       protected
 
       attr_reader :name, :config, :package_name, :repo

--- a/deploy/lib/deployer/repo/dependabot_pull_request_updater.rb
+++ b/deploy/lib/deployer/repo/dependabot_pull_request_updater.rb
@@ -9,11 +9,11 @@ class Deployer
         automerge_pr if config.automerge
       end
 
-      attr_reader :pr_url
+      attr_reader :pr_url, :skipped
 
       private
 
-      attr_writer :pr_url
+      attr_writer :pr_url, :skipped
 
       def dependabot_proxy
         repo.dependabot_proxy
@@ -40,7 +40,11 @@ class Deployer
           return log "Update not possible for #{dependency.name}"
         end
 
-        return log "No valid updates" if updated_dependencies.none?
+        if updated_dependencies.none?
+          log "No valid updates"
+          self.skipped = true
+          return
+        end
 
         log "Creating PR"
         pr = pr_creator.create
@@ -118,6 +122,7 @@ class Deployer
       end
 
       def automerge_pr
+        return if skipped
         return unless automerge
 
         log "Merging PR #{pr_number}"

--- a/deploy/lib/deployer/repo/pull_request_updater.rb
+++ b/deploy/lib/deployer/repo/pull_request_updater.rb
@@ -1,3 +1,4 @@
+\
 require_relative "base_updater"
 
 class Deployer
@@ -57,7 +58,10 @@ class Deployer
       end
 
       def pr_body
-        "This is an automated PR that updates #{package_name} to version #{version}. Please ensure that all checks pass."
+        message = "This is an automated PR that updates #{package_name} to version #{version}. Please ensure that all checks pass."
+        return "[URGENT] This release has been marked as urgent, meaning that it's deployment should be prioritized.\n\n#{message}" if config.urgent
+
+        message
       end
 
       def client

--- a/deploy/lib/deployer/reporter.rb
+++ b/deploy/lib/deployer/reporter.rb
@@ -24,7 +24,7 @@ class Deployer
           end,
         skipped_repos:
           skipped_repos.map do |repo|
-            { name: repo.name }
+            { name: repo.name, message: repo.message }
           end
       }
     end

--- a/deploy/lib/deployer/reporter.rb
+++ b/deploy/lib/deployer/reporter.rb
@@ -21,6 +21,10 @@ class Deployer
         successful_repos:
           successful_repos.map do |repo|
             { name: repo.name, pr_number: repo.pr_number, pr_url: repo.pr_url }
+          end,
+        skipped_repos:
+          skipped_repos.map do |repo|
+            { name: repo.name }
           end
       }
     end
@@ -45,6 +49,10 @@ class Deployer
 
     def successful_repos
       repos.select(&:success?)
+    end
+
+    def skipped_repos
+      repos.select(&:skipped?)
     end
   end
 end

--- a/deploy/lib/deployer/repos.rb
+++ b/deploy/lib/deployer/repos.rb
@@ -10,7 +10,7 @@ class Deployer
         repos.map do |repo|
           Repo.new(repo["name"], package_name: package_name, config: config)
         end
-      end.select(&:attempt_to_update?)
+      end.reject(&:exclude_from_reporting?)
     end
 
     private

--- a/deploy/lib/deployer/repos.rb
+++ b/deploy/lib/deployer/repos.rb
@@ -36,11 +36,5 @@ class Deployer
     def find_repos
       client.org_repos(owner).reject { |repo| repo["archived"] }
     end
-
-    def filter_repos(repos)
-      result = repos.select { |repo| only.include?(repo.name) } if only.any?
-      result = result.reject { |repo| repo["archived"] }
-      result.reject { |repo| config.exclude.include?(repo["name"]) }
-    end
   end
 end

--- a/deploy/spec/deployer/repo_spec.rb
+++ b/deploy/spec/deployer/repo_spec.rb
@@ -8,12 +8,12 @@ describe Deployer::Repo do
     )
   end
 
-  def stub_dependency(dependency = instance_double(Dependabot::Dependency, name: "test-pkg"))
-    allow(Deployer::Repo::DependabotProxy).to receive(:new).with(
-      "test",
-      config: anything,
-      package_name: "test-pkg"
-    ).and_return(instance_double(Deployer::Repo::DependabotProxy, dependency: dependency))
+  def config_file(pr_level: "all")
+    instance_double(Deployer::Repo::ConfigFile, pr_level: pr_level)
+  end
+
+  def dependabot_proxy(dependency = instance_double(Dependabot::Dependency, name: "test-pkg"))
+    instance_double(Deployer::Repo::DependabotProxy, dependency: dependency)
   end
 
   describe "#failure?" do
@@ -24,7 +24,9 @@ describe Deployer::Repo do
           "test",
           config: config,
           updater: updater,
-          package_name: "test-pkg"
+          package_name: "test-pkg",
+          config_file: config_file,
+          dependabot_proxy: dependabot_proxy
         )
 
       repo.update_package
@@ -40,7 +42,9 @@ describe Deployer::Repo do
           "test",
           config: config,
           updater: updater,
-          package_name: "test-pkg"
+          package_name: "test-pkg",
+          config_file: config_file,
+          dependabot_proxy: dependabot_proxy
         )
 
       repo.update_package
@@ -57,7 +61,9 @@ describe Deployer::Repo do
           "test",
           config: config,
           updater: updater,
-          package_name: "test-pkg"
+          package_name: "test-pkg",
+          config_file: config_file,
+          dependabot_proxy: dependabot_proxy
         )
 
       repo.update_package
@@ -73,7 +79,9 @@ describe Deployer::Repo do
           "test",
           config: config,
           updater: updater,
-          package_name: "test-pkg"
+          package_name: "test-pkg",
+          config_file: config_file,
+          dependabot_proxy: dependabot_proxy
         )
 
       repo.update_package
@@ -90,7 +98,9 @@ describe Deployer::Repo do
           "test",
           config: config,
           updater: updater,
-          package_name: "test-pkg"
+          package_name: "test-pkg",
+          config_file: config_file,
+          dependabot_proxy: dependabot_proxy
         )
 
       repo.update_package
@@ -105,7 +115,9 @@ describe Deployer::Repo do
           "test",
           config: config,
           updater: updater,
-          package_name: "test-pkg"
+          package_name: "test-pkg",
+          config_file: config_file,
+          dependabot_proxy: dependabot_proxy
         )
       allow(updater).to receive(:run).and_raise(
         Deployer::PushBranchFailure,
@@ -175,39 +187,36 @@ describe Deployer::Repo do
     it "returns true if urgent" do
       allow(config).to receive(:urgent).and_return(true)
 
-      stub_dependency
-
       repo = described_class.new(
         "test",
         config: config,
         package_name: "test-pkg",
-        config_file: instance_double(Deployer::Repo::ConfigFile, pr_level: "all")
+        config_file: instance_double(Deployer::Repo::ConfigFile, pr_level: "all"),
+        dependabot_proxy: dependabot_proxy
       )
 
       expect(repo.attempt_to_update?).to be true
     end
 
     it "returns true if the PR level is not urgent" do
-      stub_dependency
-
       repo = described_class.new(
         "test",
         config: config,
         package_name: "test-pkg",
-        config_file: instance_double(Deployer::Repo::ConfigFile, pr_level: "all")
+        config_file: instance_double(Deployer::Repo::ConfigFile, pr_level: "all"),
+        dependabot_proxy: dependabot_proxy
       )
 
       expect(repo.attempt_to_update?).to be true
     end
 
     it "returns false if the PR level is not urgent but the config file pr_level is urgent" do
-      stub_dependency
-
       repo = described_class.new(
         "test",
         config: config,
         package_name: "test-pkg",
-        config_file: instance_double(Deployer::Repo::ConfigFile, pr_level: "urgent")
+        config_file: instance_double(Deployer::Repo::ConfigFile, pr_level: "urgent"),
+        dependabot_proxy: dependabot_proxy
       )
 
       expect(repo.attempt_to_update?).to be false
@@ -216,13 +225,12 @@ describe Deployer::Repo do
     it "returns true if the PR level is urgent but the config file pr_level is urgent" do
       allow(config).to receive(:urgent).and_return(true)
 
-      stub_dependency
-
       repo = described_class.new(
         "test",
         config: config,
         package_name: "test-pkg",
-        config_file: instance_double(Deployer::Repo::ConfigFile, pr_level: "urgent")
+        config_file: instance_double(Deployer::Repo::ConfigFile, pr_level: "urgent"),
+        dependabot_proxy: dependabot_proxy
       )
 
       expect(repo.attempt_to_update?).to be true
@@ -253,26 +261,24 @@ describe Deployer::Repo do
     end
 
     it "returns true if the repo is excluded by no dependency" do
-      stub_dependency(nil)
-
       repo = described_class.new(
         "test",
         config: config,
         package_name: "test-pkg",
-        config_file: instance_double(Deployer::Repo::ConfigFile, pr_level: "all")
+        config_file: instance_double(Deployer::Repo::ConfigFile, pr_level: "all"),
+        dependabot_proxy: dependabot_proxy(nil)
       )
 
       expect(repo.exclude_from_reporting?).to be true
     end
 
     it "returns false if the repo has the dependency" do
-      stub_dependency
-
       repo = described_class.new(
         "test",
         config: config,
         package_name: "test-pkg",
-        config_file: instance_double(Deployer::Repo::ConfigFile, pr_level: "all")
+        config_file: instance_double(Deployer::Repo::ConfigFile, pr_level: "all"),
+        dependabot_proxy: dependabot_proxy
       )
 
       expect(repo.exclude_from_reporting?).to be false

--- a/deploy/spec/deployer/reporter_spec.rb
+++ b/deploy/spec/deployer/reporter_spec.rb
@@ -20,10 +20,20 @@ describe Deployer::Reporter do
       skipped?: false
     )
   end
+  let(:skipped_repo) do
+    instance_double(
+      Deployer::Repo,
+      name: "test3",
+      message: "Skipped because because repo manages non-urgent updates",
+      failure?: false,
+      success?: false,
+      skipped?: true
+    )
+  end
 
   describe "#to_json" do
     it "returns a json representation of the report" do
-      report = described_class.new([failed_repo, successful_repo])
+      report = described_class.new([failed_repo, successful_repo, skipped_repo])
 
       expect(report.to_json).to eq(
         {
@@ -35,7 +45,9 @@ describe Deployer::Reporter do
               pr_url: "http://github.com/org/repo/pull/127"
             }
           ],
-          skipped_repos: []
+          skipped_repos: [
+            { name: "test3", message: "Skipped because because repo manages non-urgent updates" }
+          ]
         }.to_json
       )
     end

--- a/deploy/spec/deployer/reporter_spec.rb
+++ b/deploy/spec/deployer/reporter_spec.rb
@@ -5,7 +5,8 @@ describe Deployer::Reporter do
       name: "test",
       error_message: "Missing permissions.",
       failure?: true,
-      success?: false
+      success?: false,
+      skipped?: false
     )
   end
   let(:successful_repo) do
@@ -15,7 +16,8 @@ describe Deployer::Reporter do
       pr_number: 127,
       pr_url: "http://github.com/org/repo/pull/127",
       failure?: false,
-      success?: true
+      success?: true,
+      skipped?: false
     )
   end
 
@@ -32,7 +34,8 @@ describe Deployer::Reporter do
               pr_number: 127,
               pr_url: "http://github.com/org/repo/pull/127"
             }
-          ]
+          ],
+          skipped_repos: []
         }.to_json
       )
     end
@@ -65,7 +68,8 @@ describe Deployer::Reporter do
         name: "test-with-`backticks`-and-'quotes'",
         error_message: "Error with `backticks` and \"quotes\"",
         failure?: true,
-        success?: false
+        success?: false,
+        skipped?: false
       )
 
       report = described_class.new([special_repo])

--- a/deploy/spec/deployer/repos_spec.rb
+++ b/deploy/spec/deployer/repos_spec.rb
@@ -1,0 +1,54 @@
+describe Deployer::Repos do
+  let(:config) do
+    Deployer::Config.new(
+      github_token: "",
+      owner: "planningcenter",
+      package_names: ["test-pkg"],
+      version: "1.2.7",
+    )
+  end
+  let(:client) { instance_double(Octokit::Client, org_repos: [{ "name" => "test-repo" }]) }
+
+  def stub_dependency(dependency = instance_double(Dependabot::Dependency, name: "test-pkg"))
+    allow(Deployer::Repo::DependabotProxy).to receive(:new).with(
+      "test-repo",
+      config: anything,
+      package_name: "test-pkg"
+    ).and_return(instance_double(Deployer::Repo::DependabotProxy, dependency: dependency))
+  end
+
+  def stub_repo_fetching
+    allow(client).to receive(:contents).with("planningcenter/test-repo", path: ".pco-release.config.yml", ref: "main").and_raise(Octokit::NotFound)
+    allow(config).to receive(:client).and_return(client)
+    stub_dependency
+  end
+
+  describe "#find" do
+    it "returns a list of repos" do
+      stub_repo_fetching
+      repos = described_class.new(config).find
+      expect(repos.map(&:name)).to eq(%w[test-repo])
+    end
+
+    it "excludes repos that are not in the only list" do
+      stub_repo_fetching
+      allow(config).to receive(:only).and_return(["other-repo"])
+      repos = described_class.new(config).find
+      expect(repos.map(&:name)).to eq([])
+    end
+
+    it "excludes repos that are in the exclude list" do
+      stub_repo_fetching
+      allow(config).to receive(:exclude).and_return(["test-repo"])
+      repos = described_class.new(config).find
+      expect(repos.map(&:name)).to eq([])
+    end
+
+    it "excludes repos that are archived" do
+      stub_repo_fetching
+      allow(client).to receive(:org_repos).and_return([{ "name" => "test-repo", "archived" => true }])
+      repos = described_class.new(config).find
+      expect(repos.map(&:name)).to eq([])
+    end
+  end
+end

--- a/reporting/action.yml
+++ b/reporting/action.yml
@@ -1,25 +1,25 @@
 name: Post results to original PR
 inputs:
   results-json:
-    description: "JSON string of results"
+    description: 'JSON string of results'
     required: true
   pr-number:
-    description: "The PR number that triggered the release"
+    description: 'The PR number that triggered the release'
     required: true
   actor:
-    description: "The actor that triggered the release"
+    description: 'The actor that triggered the release'
     required: true
   version-tag:
-    description: "The tag of the version release"
+    description: 'The tag of the version release'
     required: true
   release-type:
-    description: "The type of release"
+    description: 'The type of release'
     required: true
   proto-tag:
-    description: "The tag of the proto release (if it exists)"
+    description: 'The tag of the proto release (if it exists)'
     required: false
 runs:
-  using: "composite"
+  using: 'composite'
   steps:
     - uses: actions/github-script@v7
       env:
@@ -36,6 +36,7 @@ runs:
             const results = JSON.parse(process.env.RESULTS_JSON);
             const successfulRepoList = results.successful_repos.map(repo => `- \`${repo.name}\``).join("\n")
             const failedRepoList = results.failed_repos.map(repo => `- \`${repo.name}\`: ${repo.message}`).join("\n")
+            const skippedRepoList = results.skipped_repos && results.skipped_repos.map(repo => `- \`${repo.name}\`: ${repo.message}`).join("\n")
             return `
             ${process.env.PROTO_TAG ? `You can access the proto release at: https://${process.env.PROTO_TAG}.login.planningcenter.ninja/` : ""}
 
@@ -47,6 +48,9 @@ runs:
 
             ${failedRepoList}
 
+            ${results.skipped_repos.length > 0 ? "### Skipped the following repos:" : ""}
+
+            ${skippedRepoList}
             `
           }
 


### PR DESCRIPTION
Some of the messaging regarding updating particular packages have been less than clear.  For instance, when a repo is behind by a major version, the report would say that it updated and even create a link to a PR that doesn't exist.

With the introduction to "urgent" PRs and the ability to opt out of non-urgent PRs, it became clear that we would want to communicate clearly about these updates and that they are skipped.

In order to make this a possibility, we had to shift the status of repo updates from a binary (pass/fail), to a keyword status, with skipped being added.  Some of the logic was reworked to ensure that certain types of skips were handled correctly.  The breakdown looks like this:

| Reason | Is it reported? |
| -- | -- |
| excluded by `only` or `excluded` settings | ❌   |
| skipped because it's not urgent and repo opts out of non-urgent PRs | ✅ |
| repo doesn't depend on the library being updated | ❌ |
| version update is not allowed (usually because it would be a major upgrade) | ✅ |

The resulting status then gets posted in the report.  Skipped repos do not fail the action in the same way that errors do.

In addition, this also adds some messaging to urgent PRs sharing that they are urgent.  Dependabot does not allow control over the PR title without accessing private paths, so I opted to just include it in the body of the PR.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1210676896005873