### PR TITLE
feat: add detection for required repos that do not have permissions

### DIFF
--- a/deploy/lib/deployer.rb
+++ b/deploy/lib/deployer.rb
@@ -20,6 +20,7 @@ require_relative "deployer/repo/merge_updater"
 require_relative "deployer/repo/pull_request_updater"
 require_relative "deployer/repo/version_compare"
 require_relative "deployer/reporter"
+require_relative "deployer/skipped_repo"
 require_relative "deployer/repos"
 
 class Deployer

--- a/deploy/lib/deployer/repos.rb
+++ b/deploy/lib/deployer/repos.rb
@@ -9,7 +9,7 @@ class Deployer
       package_names.flat_map do |package_name|
         repos.map do |repo|
           Repo.new(repo["name"], package_name: package_name, config: config)
-        end
+        end + repos_without_permissions(repos)
       end.reject(&:exclude_from_reporting?)
     end
 
@@ -35,6 +35,10 @@ class Deployer
 
     def find_repos
       client.org_repos(owner).reject { |repo| repo["archived"] }
+    end
+
+    def repos_without_permissions(repos)
+      only.select { |o| !repos.any? { |repo| repo["name"] == o } }.map { |o| SkippedRepo.new(o) }
     end
   end
 end

--- a/deploy/lib/deployer/skipped_repo.rb
+++ b/deploy/lib/deployer/skipped_repo.rb
@@ -1,0 +1,43 @@
+class Deployer
+  class SkippedRepo
+    def initialize(name)
+      @name = name
+    end
+
+    attr_reader :name
+
+    def exclude_from_reporting?
+      false
+    end
+
+    def package_name
+      ""
+    end
+
+    def update_package
+      nil
+    end
+
+    def success?
+      false
+    end
+
+    def failure?
+      false
+    end
+
+    def skipped?
+      true
+    end
+
+    def message
+      "Skipped because token does not have permission to access #{name}. Ensure with platform " \
+        "that the \"Planning Center Dependencies\" Github App has permission to access this " \
+        "repository."
+    end
+
+    def error_message
+      message
+    end
+  end
+end


### PR DESCRIPTION
Currently, if you add a new repo to the list of repos that you want to deploy to and it does not have permissions, it just silently ignores the configuration.  This was making it difficult to diagnose why updates weren't getting sent out.

This small update shares that the repo was skipped because of a permissions issue and gives direction to the user on a method of getting the proper permissions set up.