### PR TITLE
feat: add OIDC support to lerna-release-pr workflow

### DIFF
--- a/.github/workflows/lerna-release-pr.yml
+++ b/.github/workflows/lerna-release-pr.yml
@@ -18,12 +18,18 @@ on:
         required: false
         type: string
         default: 'yarn'
+      use-oidc:
+        description: 'Use OIDC trusted publishing for npm authentication instead of PLANNINGCENTER_NPM_TOKEN'
+        required: false
+        type: boolean
+        default: false
 jobs:
   create-rc-release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
       pull-requests: write
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -38,7 +44,8 @@ jobs:
         with:
           cache: ${{ inputs.cache}}
           node-version: ${{ inputs.node-version }}
-      - run: echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> ~/.npmrc
+      - if: ${{ !inputs.use-oidc }}
+        run: echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> ~/.npmrc
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PLANNINGCENTER_NPM_TOKEN }}
       - run: ${{ inputs.install-command }}


### PR DESCRIPTION
## Summary
Adds opt-in OIDC trusted publishing support to the lerna release PR workflow, mirroring the pattern already implemented in `lerna-qa-release.yml` so RC publishing can authenticate via OIDC instead of `PLANNINGCENTER_NPM_TOKEN`.

## Details
- New `use-oidc` boolean input (default `false`) on `.github/workflows/lerna-release-pr.yml`
- Adds `id-token: write` permission to the `create-rc-release` job — the only job that publishes to npm
- Gates the `~/.npmrc` token-auth step on `${{ !inputs.use-oidc }}` so OIDC consumers skip writing the npm token
- The `setup-release-pr` job is intentionally unchanged because it does not publish to npm


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213911916874728