### PR TITLE
feat: add OIDC support to lerna-release-on-merge workflow

### DIFF
--- a/.github/workflows/lerna-release-on-merge.yml
+++ b/.github/workflows/lerna-release-on-merge.yml
@@ -66,6 +66,7 @@ jobs:
     permissions:
       contents: read
       id-token: write
+      packages: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/lerna-release-on-merge.yml
+++ b/.github/workflows/lerna-release-on-merge.yml
@@ -35,6 +35,11 @@ on:
         required: false
         type: string
         default: "yarn install --check-files"
+      use-oidc:
+        description: "Use OIDC trusted publishing for npm authentication instead of PLANNINGCENTER_NPM_TOKEN"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   create-release:
@@ -58,6 +63,9 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: create-release
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -68,20 +76,20 @@ jobs:
           cache: ${{ inputs.cache }}
       - run: ${{ inputs.install-command }}
       - run: ./node_modules/.bin/lerna run build
-      - name: Publish
-        run: |
-          echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> ~/.npmrc
-          ./node_modules/.bin/lerna publish from-package --yes
+      - if: ${{ !inputs.use-oidc }}
+        run: echo "//registry.npmjs.org/:_authToken=$NODE_AUTH_TOKEN" >> ~/.npmrc
         env:
           NODE_AUTH_TOKEN: ${{ secrets.PLANNINGCENTER_NPM_TOKEN }}
+      - name: Publish
+        run: ./node_modules/.bin/lerna publish from-package --yes
       - name: Publish to Github
         run: |
-          rm ~/.npmrc
+          rm -f ~/.npmrc
           echo "//npm.pkg.github.com/:_authToken=$NODE_AUTH_TOKEN" >> ~/.npmrc
           ./node_modules/.bin/lerna publish from-package --yes --registry=https://npm.pkg.github.com/:_authToken=$NODE_AUTH_TOKEN
         env:
           NODE_AUTH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - run: rm ~/.npmrc
+      - run: rm -f ~/.npmrc
   deploy:
     runs-on: ubuntu-latest
     needs: [publish, create-release]


### PR DESCRIPTION
## Summary
Adds opt-in OIDC trusted publishing support to the lerna release-on-merge workflow, mirroring the pattern already implemented in `lerna-qa-release.yml` (and matching the request to apply the same change here that was applied to QA).

## Details
- New `use-oidc` boolean input (default `false`) on `.github/workflows/lerna-release-on-merge.yml`
- Adds explicit `permissions` block to the `publish` job with `contents: read` and `id-token: write` so the npm OIDC exchange has a token to mint
- Splits the previously-bundled "Publish" step so the npm-token `~/.npmrc` write is its own step gated on `${{ !inputs.use-oidc }}`; the actual `lerna publish from-package` step always runs
- Hardens the later `~/.npmrc` removals to `rm -f` so they do not fail when OIDC was used and no token-based npmrc was written
- The "Publish to Github" step still uses `GITHUB_TOKEN` against `npm.pkg.github.com` and is intentionally unchanged in auth behavior


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213911980265808