### PR TITLE
feat: add OIDC support to publish workflow and its callers

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,6 +52,11 @@ on:
         required: false
         type: string
         default: ""
+      use-oidc:
+        description: "Use OIDC trusted publishing for npm authentication instead of PLANNINGCENTER_NPM_TOKEN"
+        required: false
+        type: boolean
+        default: false
 
 jobs:
   cache-key:
@@ -89,6 +94,9 @@ jobs:
   publish-to-npm:
     needs: [cache-key, build-and-test]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:
@@ -109,12 +117,12 @@ jobs:
         if: ${{ !inputs.prerelease }}
         run: ${{ inputs.publish-command }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.PLANNINGCENTER_NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ !inputs.use-oidc && secrets.PLANNINGCENTER_NPM_TOKEN || '' }}
       - name: Publish prerelease to NPM
         if: ${{ inputs.prerelease }}
         run: ${{ inputs.prepublish-command }}
         env:
-          NODE_AUTH_TOKEN: ${{ secrets.PLANNINGCENTER_NPM_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ !inputs.use-oidc && secrets.PLANNINGCENTER_NPM_TOKEN || '' }}
 
   publish-to-github-package-registry:
     needs: [cache-key, build-and-test]

--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -72,6 +72,11 @@ on:
         required: false
         type: string
         default: ''
+      use-oidc:
+        description: 'Use OIDC trusted publishing for npm authentication instead of PLANNINGCENTER_NPM_TOKEN'
+        required: false
+        type: boolean
+        default: false
 jobs:
   react-to-comment:
     if: github.event.issue.pull_request && contains(github.event.comment.body, '@pco-release qa')
@@ -101,6 +106,10 @@ jobs:
   publish-to-npm:
     needs: create-qa-release
     uses: planningcenter/pco-release-action/.github/workflows/publish.yml@v1
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     secrets: inherit
     with:
       install-command: ${{ inputs.install-command }}
@@ -111,6 +120,7 @@ jobs:
       build-directory: ${{ inputs.build-directory }}
       ref: ${{ needs.create-qa-release.outputs.release-tag }}
       prerelease: true
+      use-oidc: ${{ inputs.use-oidc }}
   deploy-to-proto-for-consumers:
     needs: [create-qa-release, publish-to-npm]
     runs-on: ubuntu-latest

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -62,6 +62,11 @@ on:
         required: false
         type: string
         default: 'yarn version'
+      use-oidc:
+        description: 'Use OIDC trusted publishing for npm authentication instead of PLANNINGCENTER_NPM_TOKEN'
+        required: false
+        type: boolean
+        default: false
 jobs:
   react-to-comment:
     if: github.event.issue.pull_request && contains(github.event.comment.body, '@pco-release rc')
@@ -91,6 +96,10 @@ jobs:
   publish-to-npm:
     needs: create-rc-release
     uses: planningcenter/pco-release-action/.github/workflows/publish.yml@v1
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     secrets: inherit
     with:
       install-command: ${{ inputs.install-command }}
@@ -101,6 +110,7 @@ jobs:
       build-directory: ${{ inputs.build-directory }}
       ref: ${{ needs.create-rc-release.outputs.release-tag }}
       prerelease: true
+      use-oidc: ${{ inputs.use-oidc }}
   deploy-to-staging-for-consumers:
     needs: [create-rc-release, publish-to-npm]
     runs-on: ubuntu-latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -61,6 +61,11 @@ on:
         required: false
         type: string
         default: "package.json"
+      use-oidc:
+        description: "Use OIDC trusted publishing for npm authentication instead of PLANNINGCENTER_NPM_TOKEN"
+        required: false
+        type: boolean
+        default: false
 jobs:
   create-release:
     runs-on: ubuntu-latest
@@ -77,6 +82,10 @@ jobs:
   publish-to-npm:
     needs: create-release
     uses: planningcenter/pco-release-action/.github/workflows/publish.yml@v1
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
     secrets: inherit
     with:
       install-command: ${{ inputs.install-command }}
@@ -87,6 +96,7 @@ jobs:
       build-directory: ${{ inputs.build-directory }}
       ref: ${{ needs.create-release.outputs.release-tag }}
       prerelease: false
+      use-oidc: ${{ inputs.use-oidc }}
   deploy-to-consumers:
     needs: [create-release, publish-to-npm]
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
Adds opt-in OIDC trusted publishing support to `publish.yml` and plumbs the flag through the three reusable workflows that call it (`release.yml`, `release-candidate.yml`, `qa-release.yml`), mirroring the OIDC pattern already shipped in `lerna-qa-release.yml`.

## Details

### `publish.yml`
- New `use-oidc` boolean input (default `false`)
- Adds `id-token: write` (with `contents: read`) permission to the `publish-to-npm` job
- `NODE_AUTH_TOKEN` on the publish steps is now `${{ !inputs.use-oidc && secrets.PLANNINGCENTER_NPM_TOKEN || '' }}` so in OIDC mode the token substitution in `~/.npmrc` resolves to empty, npm sees no configured auth, and falls through to its OIDC trusted-publishing flow
- Intentionally kept the existing `setup-node` `registry-url` + `always-auth` approach rather than switching to a manual `~/.npmrc` write, to keep the diff minimal

### Caller workflows (`release.yml`, `release-candidate.yml`, `qa-release.yml`)
- Each gains a `use-oidc` input that forwards to the `publish.yml` call
- Each calling job now declares `permissions: { contents: read, packages: write, id-token: write }` — required because reusable workflows cannot claim permissions the caller did not grant

### Release / tagging caveat
The callers reference `publish.yml@v1` by explicit tag. The `v1` tag must be moved forward after this PR merges before any consumer (or these internal callers) can actually pass `use-oidc` — otherwise GHA rejects the input as undefined against the old tagged version of `publish.yml`. The LSP warnings of the form `use-oidc is not defined in the referenced workflow` are surfacing exactly this: they compare the local source against the tagged remote.

### Relationship to prior OIDC work
Same opt-in shape as `lerna-qa-release.yml`: default off, consumers flip `use-oidc: true` once their package is enrolled in npm trusted publishing. As discussed offline, OIDC only *supplements* token auth — to actually enforce workflow-identity-based publishing, the long-lived `PLANNINGCENTER_NPM_TOKEN` also needs to be revoked on the npmjs side; otherwise flipping the flag just buys provenance attestations and short-lived credentials without closing the token backdoor.


---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1213911916869963