### PR TITLE
fix: make id-token permission inherited so non-OIDC repos don't fail validation

### DIFF
--- a/.github/workflows/lerna-qa-release.yml
+++ b/.github/workflows/lerna-qa-release.yml
@@ -68,10 +68,6 @@ jobs:
   create-qa-release:
     if: github.event.issue.pull_request && startsWith(github.event.comment.body, '@pco-release qa')
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
-      pull-requests: write
-      id-token: write
     steps:
       - name: Get PR head ref
         id: get-pr-ref

--- a/.github/workflows/lerna-release-on-merge.yml
+++ b/.github/workflows/lerna-release-on-merge.yml
@@ -63,10 +63,6 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     needs: create-release
-    permissions:
-      contents: read
-      id-token: write
-      packages: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,9 +1,5 @@
 name: Publish package on GitHub release
 
-permissions:
-  contents: read
-  packages: write
-
 on:
   workflow_call:
     inputs:
@@ -99,9 +95,6 @@ jobs:
   publish-to-npm:
     needs: [cache-key, build-and-test]
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      id-token: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/qa-release.yml
+++ b/.github/workflows/qa-release.yml
@@ -111,10 +111,6 @@ jobs:
   publish-to-npm:
     needs: create-qa-release
     uses: planningcenter/pco-release-action/.github/workflows/publish.yml@v1
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
     secrets: inherit
     with:
       install-command: ${{ inputs.install-command }}

--- a/.github/workflows/release-candidate.yml
+++ b/.github/workflows/release-candidate.yml
@@ -101,10 +101,6 @@ jobs:
   publish-to-npm:
     needs: create-rc-release
     uses: planningcenter/pco-release-action/.github/workflows/publish.yml@v1
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
     secrets: inherit
     with:
       install-command: ${{ inputs.install-command }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -87,10 +87,6 @@ jobs:
   publish-to-npm:
     needs: create-release
     uses: planningcenter/pco-release-action/.github/workflows/publish.yml@v1
-    permissions:
-      contents: read
-      packages: write
-      id-token: write
     secrets: inherit
     with:
       install-command: ${{ inputs.install-command }}


### PR DESCRIPTION
## Summary

Fixes workflow validation errors for repos that haven't yet transitioned to OIDC trusted publishing. The `id-token: write` permission was unconditionally requested in reusable workflow jobs, causing GitHub to reject workflows at parse time for callers that don't grant that permission.

## Details

GitHub validates reusable workflow permissions at parse time, not runtime. When we added OIDC support, we added `id-token: write` to the `permissions` blocks in several jobs across the reusable workflows. This meant that even repos with `use-oidc: false` (the default) would fail validation if their calling workflow didn't explicitly grant `id-token: write`.

The error:
```
The nested job 'publish-to-npm' is requesting 'id-token: write', but is only allowed 'id-token: none'
```

The fix removes explicit `permissions` blocks from jobs that need optional `id-token: write`, allowing permissions to be **inherited from the caller** instead. This means:
- **Non-OIDC repos**: No `id-token` is requested anywhere, no validation error
- **OIDC repos**: The caller grants `id-token: write` in their workflow, and it flows through the inheritance chain to the publish jobs

### Files changed

| File | Change |
|---|---|
| `publish.yml` | Removed top-level `permissions` and `publish-to-npm` job permissions |
| `release.yml` | Removed `publish-to-npm` job permissions |
| `release-candidate.yml` | Removed `publish-to-npm` job permissions |
| `qa-release.yml` | Removed `publish-to-npm` job permissions |
| `lerna-release-on-merge.yml` | Removed `publish` job permissions |
| `lerna-qa-release.yml` | Removed `create-qa-release` job permissions |
